### PR TITLE
For #31249, overwriting scene files

### DIFF
--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -63,7 +63,7 @@ class NewFileAction(FileAction):
                 # and raise a new, clearer exception for this specific use case:
                 raise TankError("Unable to resolve template fields after folder creation!  This could mean "
                                 "there is a mismatch between your folder schema and templates.  Please email "
-                        "toolkitsupport@shotgunsoftware.com if you need help fixing this.") 
+                                "support@shotgunsoftware.com if you need help fixing this.") 
 
             # reset the current scene:
             if not reset_current_scene(self._app, NEW_FILE_ACTION, self.environment.context):

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -377,7 +377,7 @@ class FileModel(QtGui.QStandardItemModel):
                             searching for files.
         :returns:           A dictionary {version:FileItem} of all file versions found.
         """
-        return self._search_cache.find_file_versions(work_area, key)
+        return self._search_cache.find_file_versions(work_area, key, include_dirty=not clean_only)
 
     def items_from_file(self, file_item, ignore_version = False):
         """

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -377,7 +377,7 @@ class FileModel(QtGui.QStandardItemModel):
                             searching for files.
         :returns:           A dictionary {version:FileItem} of all file versions found.
         """
-        return self._search_cache.find_file_versions(work_area, key, include_dirty=not clean_only)
+        return self._search_cache.find_file_versions(work_area, key, clean_only)
 
     def items_from_file(self, file_item, ignore_version = False):
         """

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -67,17 +67,17 @@ class FileSaveForm(FileFormBase):
             preview_colour = font_colour.darker(140)
         self._preview_colour = (preview_colour.red(), preview_colour.green(), preview_colour.blue())
 
-        self._initializing = True
+        self._disallow_preview_update = True
         try:
             # doing this inside a try-except to ensure any exceptions raised don't 
             # break the UI and crash the dcc horribly!
             self._do_init()
-            self._initializing = False
+            self._disallow_preview_update = False
             # Manually invoke the preview update here so it is only called once due to the
-            # _initializing flag.
+            # _disallow_preview_update flag.
             self._start_preview_update()
         except:
-            self._initializing = False
+            self._disallow_preview_update = False
             app.log_exception("Unhandled exception during File Save Form construction!")
 
     def _do_init(self):
@@ -195,7 +195,7 @@ class FileSaveForm(FileFormBase):
         # to avoid creating and deleting the preview task multiple times, which is not only
         # wasteful but also makes the code harder to debug since 5 tasks end up computing
         # the preview.
-        if self._initializing:
+        if self._disallow_preview_update:
             return
 
         # Disable the button while the path is computed.

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -333,7 +333,7 @@ class FileSaveForm(FileFormBase):
                 # and raise a new, clearer exception for this specific use case:
                 raise TankError("Unable to resolve template fields!  This could mean there is a mismatch "
                                 "between your folder schema and templates.  Please email "
-                                "toolkitsupport@shotgunsoftware.com if you need help fixing this.")
+                                "support@shotgunsoftware.com if you need help fixing this.")
 
             # it's ok not to have a path preview at this point!
             return {}

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -74,14 +74,14 @@ class FileSaveForm(FileFormBase):
             # break the UI and crash the dcc horribly!
             self._initializing = True
             self._do_init()
+            self._initializing = False
             # Manually invoke the preview update here so it is only called once due to the
             # _initializing flag.
             self._start_preview_update()
         except:
-            app.log_exception("Unhandled exception during File Save Form construction!")
-        finally:
             self._initializing = False
-        
+            app.log_exception("Unhandled exception during File Save Form construction!")
+
     def _do_init(self):
         """
         Actual construction!
@@ -326,7 +326,6 @@ class FileSaveForm(FileFormBase):
             # need a file key to find all versions so lets build it:
             file_key = FileItem.build_file_key(fields, env.work_template, 
                                                env.version_compare_ignore_fields)
-
             file_versions = None
             if self._file_model:
                 file_versions = self._file_model.get_cached_file_versions(file_key, env, clean_only=True)

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -67,17 +67,17 @@ class FileSaveForm(FileFormBase):
             preview_colour = font_colour.darker(140)
         self._preview_colour = (preview_colour.red(), preview_colour.green(), preview_colour.blue())
 
-        self._disallow_preview_update = True
+        self._allow_preview_update = False
         try:
             # doing this inside a try-except to ensure any exceptions raised don't 
             # break the UI and crash the dcc horribly!
             self._do_init()
-            self._disallow_preview_update = False
+            self._allow_preview_update = True
             # Manually invoke the preview update here so it is only called once due to the
-            # _disallow_preview_update flag.
+            # _allow_preview_update flag.
             self._start_preview_update()
         except:
-            self._disallow_preview_update = False
+            self._allow_preview_update = True
             app.log_exception("Unhandled exception during File Save Form construction!")
 
     def _do_init(self):
@@ -195,7 +195,7 @@ class FileSaveForm(FileFormBase):
         # to avoid creating and deleting the preview task multiple times, which is not only
         # wasteful but also makes the code harder to debug since 5 tasks end up computing
         # the preview.
-        if self._disallow_preview_update:
+        if not self._allow_preview_update:
             return
 
         # Disable the button while the path is computed.

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -191,7 +191,7 @@ class FileSaveForm(FileFormBase):
         """
         # When initializing the gui, the event is fired multiple times due to signals
         # emitted from the widgets. Here we are muting the start_preview_update call
-        # to creating and deleting the preview task multiple times, which is not only
+        # to avoid creating and deleting the preview task multiple times, which is not only
         # wasteful but also makes the code harder to debug since 5 tasks end up computing
         # the preview.
         if self._initializing:

--- a/python/tk_multi_workfiles/file_search_cache.py
+++ b/python/tk_multi_workfiles/file_search_cache.py
@@ -85,14 +85,14 @@ class FileSearchCache(Threaded):
         self._cache[key] = new_entry
 
     @Threaded.exclusive
-    def find_file_versions(self, work_area, file_key, include_dirty=True):
+    def find_file_versions(self, work_area, file_key, clean_only=False):
         """
         Find all file versions for the specified file key and context.
 
         :param work_area:       The work area to find the file version for
         :param file_key:        A unique file key that can be used to locate all versions of a single file
-        :param include_dirty:   If True then dirty cache entries will be included in the returned results.  If
-                                False then they will be omitted.
+        :param clean_only:      If False then dirty cache entries will be included in the returned results.  If
+                                True then they will be omitted. Defaults to False.
         :returns:               A dictionary {version:FileItem} of all file versions found.
         """
         _, entry = self._find_entry(work_area)
@@ -100,7 +100,7 @@ class FileSearchCache(Threaded):
             # return None as we don't have a cached result for this context!
             return None
 
-        if not include_dirty and entry.is_dirty:
+        if clean_only and entry.is_dirty:
             return None
 
         file_info = entry.file_info.get(file_key)


### PR DESCRIPTION
If we let the model refresh it's state before clicking save, clicking it will invoke _generate_path and the cached value will be read.

If we don't wait for the background task to finish indexing the files, then we will get partial results and an incorrect version number.

This is because when the FileModel requests for the cache file versions it doesn't honour the clean_only flag that _generate_path to it. Because of this, the file model actually returns dirty cache entries. Honouring the flag when communicating with the cache will return None when the model is still being populated and the _generate_path will compute the value itself on the spot instead of waiting for the background task.