### PR TITLE
Bumps Shotgun Utils framework to major version 4

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -175,7 +175,7 @@ configuration:
 requires_shotgun_fields:
 
 # More verbose description of this item 
-display_name: "Manage your Work Files 2"
+display_name: "Shotgun File Manager"
 description: "Using this app you can browse, open and save 
               your Work Files and Publishes."
               
@@ -189,7 +189,6 @@ supported_engines:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-widget", "version": "v0.2.x"}
-    - {"name": "tk-framework-shotgunutils", "version": "v3.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}    
     

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -23,8 +23,8 @@ from .user_cache import g_user_cache
 
 from .sg_published_files_model import SgPublishedFilesModel
 
-shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
-BackgroundTaskManager = shotgun_data.BackgroundTaskManager
+task_manager = sgtk.platform.import_framework("tk-framework-shotgunutils", "task_manager")
+BackgroundTaskManager = task_manager.BackgroundTaskManager
 
 from .work_area import WorkArea
 from .util import monitor_qobject_lifetime, Threaded

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -18,8 +18,8 @@ from itertools import chain
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
-shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
-BackgroundTaskManager = shotgun_data.BackgroundTaskManager
+task_manager = sgtk.platform.import_framework("tk-framework-shotgunutils", "task_manager")
+BackgroundTaskManager = task_manager.BackgroundTaskManager
 
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 ShotgunEntityModel = shotgun_model.ShotgunEntityModel


### PR DESCRIPTION
This bumps the shotgun utils fw to major version 4 and tweaks the display name to say `Shotgun File Manager` rather than the technical sounding `Manage your Work Files 2`. The unused fw dependency on the old widget fw is dropped.