### PR TITLE
For #33041, previous versions menu

### DIFF
--- a/python/tk_multi_workfiles/actions/action.py
+++ b/python/tk_multi_workfiles/actions/action.py
@@ -1,19 +1,18 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 """
 
 import sgtk
-from sgtk import TankError
-from sgtk.platform.qt import QtGui, QtCore
+
 
 class Action(object):
     """
@@ -23,15 +22,29 @@ class Action(object):
         """
         self._app = sgtk.platform.current_bundle()
         self._label = label
-        
+
     @property
     def label(self):
         return self._label
-    
+
     def execute(self, parent_ui):
         """
         """
         raise NotImplementedError("Implementation of _execute() method missing for action '%s'" % self.label)
+
+
+class ActionGroup(Action):
+
+    def __init__(self, label, actions):
+        """
+        """
+        Action.__init__(self, label)
+        self.__actions = actions
+
+    @property
+    def actions(self):
+        return self.__actions
+
 
 class SeparatorAction(Action):
     """

--- a/python/tk_multi_workfiles/actions/action.py
+++ b/python/tk_multi_workfiles/actions/action.py
@@ -9,49 +9,77 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
+Menu actions.
 """
 
 import sgtk
 
 
-class Action(object):
+class ActionBase(object):
     """
+    Base class for Actions.
     """
     def __init__(self, label):
         """
+        Constructor.
+
+        :param label: Name of the action.
         """
         self._app = sgtk.platform.current_bundle()
         self._label = label
 
     @property
     def label(self):
+        """
+        :returns: The name of the action.
+        """
         return self._label
+
+
+class Action(ActionBase):
+    """
+    Base class for leaf actions, ie, actions that when selected execute a piece of logic. This logic
+    is implemented in the execute method.
+    """
 
     def execute(self, parent_ui):
         """
+        Called when the user executes a given action. The default implementation raises a NotImplementedError.
+
+        :raises NotImplementedError: Thrown if a derived class doesn't implement this method and the client invokes it.
         """
         raise NotImplementedError("Implementation of _execute() method missing for action '%s'" % self.label)
 
 
-class ActionGroup(Action):
+class ActionGroup(ActionBase):
+    """
+    Group of actions.
+    """
 
     def __init__(self, label, actions):
         """
+        Constructor.
+
+        :param label: Name of the group of actions.
+        :param actions: List of ActionBase actions.
         """
-        Action.__init__(self, label)
-        self.__actions = actions
+        ActionBase.__init__(self, label)
+        self.__actions = actions[:]
 
     @property
     def actions(self):
+        """
+        :returns: List of ActionBase actions.
+        """
         return self.__actions
 
 
-class SeparatorAction(Action):
+class SeparatorAction(ActionBase):
     """
+    Not an actual action but a hint to the UI that a separation should be shown.
     """
     def __init__(self):
-        Action.__init__(self, "---")
-
-    def execute(self, parent_ui):
-        # do nothing!
-        pass
+        """
+        Constructor.
+        """
+        ActionBase.__init__(self, "---")

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -54,7 +54,7 @@ class FileActionFactory(object):
         :param publishes_visible: True if publishes are visible. Defauls to True.
         """
         self._work_area = work_area
-        self._file_item_model = file_model
+        self._file_model = file_model
         self._workfiles_visible = workfiles_visible
         self._publishes_visible = publishes_visible
 
@@ -68,11 +68,11 @@ class FileActionFactory(object):
         )
 
         # determine if this file is in a different work area:
-        user_work_area = work_area
+        self._user_work_area = work_area
         self._change_work_area = (work_area.context != app.context)
         if self._change_work_area and self._in_other_users_sandbox:
-            user_work_area = work_area.create_copy_for_user(g_user_cache.current_user)
-            self._change_work_area = (user_work_area.context != app.context)
+            self._user_work_area = work_area.create_copy_for_user(g_user_cache.current_user)
+            self._change_work_area = (self._user_work_area.context != app.context)
 
         # and if it's possible to copy this file to the work area:
         self._can_copy_to_work_area = False

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
+File open menu factory.
 """
 import sgtk
 
@@ -27,7 +28,7 @@ from .open_publish_actions import CopyAndOpenPublishInCurrentWorkAreaAction
 from .new_file_action import NewFileAction
 
 from .show_in_filesystem_action import ShowWorkFileInFileSystemAction, ShowPublishInFileSystemAction
-from .show_in_filesystem_action import ShowWorkAreaInFileSystemAction, ShowPublishAreaInFileSystemAction 
+from .show_in_filesystem_action import ShowWorkAreaInFileSystemAction, ShowPublishAreaInFileSystemAction
 from .show_in_shotgun_action import ShowPublishInShotgunAction, ShowLatestPublishInShotgunAction
 
 from .custom_file_action import CustomFileAction
@@ -36,12 +37,39 @@ from ..work_area import WorkArea
 from ..file_item import FileItem
 from ..user_cache import g_user_cache
 
+
 class FileActionFactory(object):
     """
+    Builder for the file open menu. Based on the current selection, the build will enumerate a list of actions,
+    grouped actions and seperators that should be displayed in the UI.
     """
-    
-    def get_actions(self, file, work_area, file_model, workfiles_visible=True, publishes_visible=True, recurse=True):
+
+    def get_actions(self, file, work_area, file_model, workfiles_visible=True, publishes_visible=True):
         """
+        Retrives the list of actions for the given file.
+
+        :param file: FileItem instance representing the selection in the browser.
+        :param work_area: WorkArea instance representing the context associate with the file.
+        :param file_model: A FileModel instance.
+        :param workfiles_visible: True if workfiles are visible.
+        :param publishes_visible: True if publishes are visible.
+
+        :returns: List of Actions.
+        """
+        return self.__get_actions(file, work_area, file_model, workfiles_visible, publishes_visible, first_level=True)
+
+    def __get_actions(self, file, work_area, file_model, workfiles_visible, publishes_visible, first_level):
+        """
+        Retrives the list of actions for the given file, recursively.
+
+        :param file: FileItem instance representing the selection in the browser.
+        :param work_area: WorkArea instance representing the context associate with the file.
+        :param file_model: A FileModel instance.
+        :param workfiles_visible: True if workfiles are visible, False otherwise.
+        :param publishes_visible: True if publishes are visible, False otherwise.
+        :param first_level: True if we are at the root of the actions list, False otherwise.
+
+        :returns: List of Actions.
         """
         if not file or not work_area or not file_model:
             return []
@@ -49,8 +77,8 @@ class FileActionFactory(object):
         app = sgtk.platform.current_bundle()
 
         # determine if this file is in a different users sandbox:
-        in_other_users_sandbox = (work_area.contains_user_sandboxes 
-                                  and work_area.context.user and g_user_cache.current_user 
+        in_other_users_sandbox = (work_area.contains_user_sandboxes
+                                  and work_area.context.user and g_user_cache.current_user
                                   and work_area.context.user["id"] != g_user_cache.current_user["id"])
 
         # determine if this file is in a different work area:
@@ -66,7 +94,7 @@ class FileActionFactory(object):
             current_env = WorkArea(app.context)
             can_copy_to_work_area = current_env.work_template is not None
             # (AD) TODO - it's possible the work template for the current work area has different requirements than
-            # the source work area (e.g. it may require a name where the source work template doesn't!)  This should 
+            # the source work area (e.g. it may require a name where the source work template doesn't!)  This should
             # probably check that file.path is translatable to the current work area (contains all the required keys)
             # in addition to the simple check it's currently doing.
 
@@ -96,13 +124,15 @@ class FileActionFactory(object):
 
         actions = []
 
-        # always add the interactive 'open' action.  This is the
-        # default/generic open action that gets run whenever someone
-        # double-clicks on a file or just hits the 'Open' button
-        actions.append(InteractiveOpenAction(file, file_versions, work_area, workfiles_visible, publishes_visible))
+        # Default Open is only at the root level.
+        if first_level:
+            # add the interactive 'open' action.  This is the
+            # default/generic open action that gets run whenever someone
+            # double-clicks on a file or just hits the 'Open' button
+            actions.append(InteractiveOpenAction(file, file_versions, work_area, workfiles_visible, publishes_visible))
 
-        #if workfiles_visible and file.is_local:
         if file.is_local:
+            # if workfiles_visible and file.is_local:
             # all actions available when selection is a work file
 
             # ------------------------------------------------------------------
@@ -137,22 +167,27 @@ class FileActionFactory(object):
             actions.append(SeparatorAction())
             actions.append(OpenPublishAction(file, file_versions, work_area))
             if file.path:
-                # file has a local path so it's possible to carry copy it to the local work area! 
+                # file has a local path so it's possible to carry copy it to the local work area!
                 actions.append(ContinueFromPublishAction(file, current_user_file_versions, work_area))
 
                 if change_work_area and can_copy_to_work_area:
                     actions.append(CopyAndOpenPublishInCurrentWorkAreaAction(file, current_user_file_versions, work_area))
 
-        if recurse:
+        # If we are at the first level of the menu, we will show previous versions of the current file,
+        # if available.
+        if first_level:
             # ------------------------------------------------------------------
             actions.append(SeparatorAction())
-            if workfiles_visible:
-                actions.extend(self._create_previous_versions_actions(file, work_area, file_model, pick_locals=True))
+            actions.extend(self.__create_previous_versions_actions(
+                file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=True)
+            )
 
-            if publishes_visible:
-                actions.extend(self._create_previous_versions_actions(file, work_area, file_model, pick_locals=False))
+            actions.extend(self.__create_previous_versions_actions(
+                file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=False)
+            )
 
-        if not in_other_users_sandbox:
+        # A New File can only be created from the first level of the menu.
+        if first_level and not in_other_users_sandbox:
             if NewFileAction.can_do_new_file(work_area):
                 # New file action
 
@@ -161,15 +196,15 @@ class FileActionFactory(object):
                 actions.append(NewFileAction(file, file_versions, work_area))
 
         # query for any custom actions:
-        custom_actions = CustomFileAction.get_action_details(file, file_versions, work_area, 
-                                                          workfiles_visible, publishes_visible)
+        custom_actions = CustomFileAction.get_action_details(file, file_versions, work_area,
+                                                             workfiles_visible, publishes_visible)
         if custom_actions:
             # ------------------------------------------------------------------
             actions.append(SeparatorAction())
         for action_dict in custom_actions:
             name = action_dict.get("name")
             label = action_dict.get("caption") or name
-            custom_action = CustomFileAction(name, label, file, file_versions, work_area, 
+            custom_action = CustomFileAction(name, label, file, file_versions, work_area,
                                              workfiles_visible, publishes_visible)
             actions.append(custom_action)
 
@@ -186,7 +221,7 @@ class FileActionFactory(object):
             show_in_actions.append(ShowPublishInShotgunAction(file, file_versions, work_area))
         else:
             if work_area.publish_area_template:
-                show_in_actions.append(ShowPublishAreaInFileSystemAction(file, file_versions, work_area))            
+                show_in_actions.append(ShowPublishAreaInFileSystemAction(file, file_versions, work_area))
 
             # see if we have any publishes:
             publish_versions = [v for v, f in file_versions.iteritems() if f.is_published]
@@ -195,13 +230,24 @@ class FileActionFactory(object):
 
         if show_in_actions:
             # ------------------------------------------------------------------
-            actions.append(SeparatorAction())            
+            actions.append(SeparatorAction())
             actions.extend(show_in_actions)
 
         return actions
 
-    def _create_previous_versions_actions(self, file, work_area, file_model, pick_locals):
+    def __create_previous_versions_actions(self, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals):
+        """
+        Retrives the list of actions for all the previous versions of a given type.
 
+        :param file: FileItem instance representing the selection in the browser.
+        :param work_area: WorkArea instance representing the context associate with the file.
+        :param file_model: A FileModel instance.
+        :param workfiles_visible: True if workfiles are visible, False otherwise.
+        :param publishes_visible: True if publishes are visible, False otherwise.
+        :param pick_locals: True if we want to show previous actions for workfiles, False if we want them for publishes.
+
+        :returns: List of Actions.
+        """
         # Pick the right verion type.
         if pick_locals:
             previous_versions = [item for item in file.versions.values() if file.version > item.version and item.is_local]
@@ -213,14 +259,13 @@ class FileActionFactory(object):
             return []
 
         previous_versions_actions = []
-        # Gives us the last twenty versions, from the latest to the earliest.
-        for item in previous_versions[-1:-21:-1]:
-            version_actions = self.get_actions(
+        # Gives us the last ten versions, from the latest to the earliest.
+        for item in previous_versions[-1:-11:-1]:
+            version_actions = self.__get_actions(
                 item, work_area, file_model,
-                workfiles_visible=pick_locals is True,
-                publishes_visible=pick_locals is False,
-                recurse=False
+                workfiles_visible, publishes_visible,
+                first_level=False
             )
             previous_versions_actions.append(ActionGroup("Version %d" % item.version, version_actions))
 
-        return [ActionGroup("Previous versions" if pick_locals else "Previous published versions", previous_versions_actions)]
+        return [ActionGroup("Previous Work Files" if pick_locals else "Previous Publishes", previous_versions_actions)]

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -178,12 +178,12 @@ class FileActionFactory(object):
         if first_level:
             # ------------------------------------------------------------------
             actions.append(SeparatorAction())
-            actions.extend(self.__create_previous_versions_actions(
-                file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=True)
+            self.__append_previous_versions_actions(
+                actions, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=True
             )
 
-            actions.extend(self.__create_previous_versions_actions(
-                file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=False)
+            self.__append_previous_versions_actions(
+                actions, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=False
             )
 
         # A New File can only be created from the first level of the menu.
@@ -235,7 +235,7 @@ class FileActionFactory(object):
 
         return actions
 
-    def __create_previous_versions_actions(self, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals):
+    def __append_previous_versions_actions(self, actions, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals):
         """
         Retrives the list of actions for all the previous versions of a given type.
 
@@ -256,7 +256,7 @@ class FileActionFactory(object):
 
         # If there are no previous versions to show, return an empty list.
         if not previous_versions:
-            return []
+            return 
 
         previous_versions_actions = []
         # Gives us the last ten versions, from the latest to the earliest.
@@ -268,4 +268,6 @@ class FileActionFactory(object):
             )
             previous_versions_actions.append(ActionGroup("Version %d" % item.version, version_actions))
 
-        return [ActionGroup("Previous Work Files" if pick_locals else "Previous Publishes", previous_versions_actions)]
+        actions.append(
+            ActionGroup("Previous Work Files" if pick_locals else "Previous Publishes", previous_versions_actions)
+        )

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -204,9 +204,9 @@ class FileActionFactory(object):
 
         # Pick the right verion type.
         if pick_locals:
-            previous_versions = [item for item in file.versions.values() if item.is_local]
+            previous_versions = [item for item in file.versions.values() if file.version > item.version and item.is_local]
         else:
-            previous_versions = [item for item in file.versions.values() if item.is_published]
+            previous_versions = [item for item in file.versions.values() if file.version > item.version and item.is_published]
 
         # If there are no previous versions to show, return an empty list.
         if not previous_versions:

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -44,83 +44,99 @@ class FileActionFactory(object):
     grouped actions and seperators that should be displayed in the UI.
     """
 
-    def get_actions(self, file, work_area, file_model, workfiles_visible=True, publishes_visible=True):
+    def __init__(self, file, work_area, file_model, workfiles_visible=True, publishes_visible=True):
         """
-        Retrives the list of actions for the given file.
+        Constructor.
 
         :param file: FileItem instance representing the selection in the browser.
         :param work_area: WorkArea instance representing the context associate with the file.
         :param file_model: A FileModel instance.
-        :param workfiles_visible: True if workfiles are visible.
-        :param publishes_visible: True if publishes are visible.
-
-        :returns: List of Actions.
+        :param workfiles_visible: True if workfiles are visible. Defauls to True.
+        :param publishes_visible: True if publishes are visible. Defauls to True.
         """
-        return self.__get_actions(file, work_area, file_model, workfiles_visible, publishes_visible, first_level=True)
+        self._file = file
+        self._work_area = work_area
+        self._file_model = file_model
+        self._workfiles_visible = workfiles_visible
+        self._publishes_visible = publishes_visible
 
-    def __get_actions(self, file, work_area, file_model, workfiles_visible, publishes_visible, first_level):
-        """
-        Retrives the list of actions for the given file, recursively.
+        if self._is_invalid():
+            return
 
-        :param file: FileItem instance representing the selection in the browser.
-        :param work_area: WorkArea instance representing the context associate with the file.
-        :param file_model: A FileModel instance.
-        :param workfiles_visible: True if workfiles are visible, False otherwise.
-        :param publishes_visible: True if publishes are visible, False otherwise.
-        :param first_level: True if we are at the root of the actions list, False otherwise.
-
-        :returns: List of Actions.
-        """
-        if not file or not work_area or not file_model:
-            return []
-
-        app = sgtk.platform.current_bundle()
+        self._app = sgtk.platform.current_bundle()
 
         # determine if this file is in a different users sandbox:
-        in_other_users_sandbox = (work_area.contains_user_sandboxes
-                                  and work_area.context.user and g_user_cache.current_user
-                                  and work_area.context.user["id"] != g_user_cache.current_user["id"])
+        self._in_other_users_sandbox = (
+            work_area.contains_user_sandboxes
+            and work_area.context.user and g_user_cache.current_user
+            and work_area.context.user["id"] != g_user_cache.current_user["id"]
+        )
 
         # determine if this file is in a different work area:
-        user_work_area = work_area
-        change_work_area = (work_area.context != app.context)
-        if change_work_area and in_other_users_sandbox:
-            user_work_area = work_area.create_copy_for_user(g_user_cache.current_user)
-            change_work_area = (user_work_area.context != app.context)
+        self._user_work_area = work_area
+        self._change_work_area = (work_area.context != self._app.context)
+        if self._change_work_area and self._in_other_users_sandbox:
+            self._user_work_area = work_area.create_copy_for_user(g_user_cache.current_user)
+            self._change_work_area = (self._user_work_area.context != self._app.context)
 
         # and if it's possible to copy this file to the work area:
-        can_copy_to_work_area = False
-        if change_work_area and app.context:
-            current_env = WorkArea(app.context)
-            can_copy_to_work_area = current_env.work_template is not None
+        self._can_copy_to_work_area = False
+        if self._change_work_area and self._app.context:
+            current_env = WorkArea(self._app.context)
+            self._can_copy_to_work_area = current_env.work_template is not None
             # (AD) TODO - it's possible the work template for the current work area has different requirements than
             # the source work area (e.g. it may require a name where the source work template doesn't!)  This should
             # probably check that file.path is translatable to the current work area (contains all the required keys)
             # in addition to the simple check it's currently doing.
 
         # get the list of file versions for the file:
-        file_versions = file.versions
-        current_user_file_versions = {}
-        if in_other_users_sandbox:
+        self._file_versions = file.versions
+        self._current_user_file_versions = {}
+        if self._in_other_users_sandbox:
             # build a file key by extracting fields from the path:
             template = None
             path = None
-            if file.path and user_work_area.work_area_contains_user_sandboxes:
+            if file.path and self._user_work_area.work_area_contains_user_sandboxes:
                 path = file.path
-                template = user_work_area.work_template
-            elif file.publish_path and user_work_area.publish_area_contains_user_sandboxes:
+                template = self._user_work_area.work_template
+            elif file.publish_path and self._user_work_area.publish_area_contains_user_sandboxes:
                 path = file.publish_path
-                template = user_work_area.publish_template
+                template = self._user_work_area.publish_template
 
             if template and path:
                 fields = template.get_fields(path)
-                ctx_fields = user_work_area.context.as_template_fields(template)
+                ctx_fields = self._user_work_area.context.as_template_fields(template)
                 fields.update(ctx_fields)
-                file_key = FileItem.build_file_key(fields, template, user_work_area.version_compare_ignore_fields)
-                current_user_file_versions = file_model.get_cached_file_versions(file_key, user_work_area) or {}
+                file_key = FileItem.build_file_key(fields, template, self._user_work_area.version_compare_ignore_fields)
+                self._current_user_file_versions = file_model.get_cached_file_versions(file_key, self._user_work_area) or {}
         else:
             # not using sandboxes so the two lists of versions are the same
-            current_user_file_versions = file_versions
+            self._current_user_file_versions = self._file_versions
+
+    def _is_invalid(self):
+        if not self._file or not self._work_area or not self._file_model:
+            return True
+        else:
+            return False
+
+    def get_actions(self):
+        """
+        Retrives the list of actions for the given file.
+        :returns: List of Actions.
+        """
+        return self.__get_actions(self._file, first_level=True)
+
+    def __get_actions(self, file, first_level):
+        """
+        Retrives the list of actions for the given file, recursively.
+
+        :param first_level: True if we are at the root of the actions list, False otherwise.
+
+        :returns: List of Actions.
+        """
+
+        if self._is_invalid():
+            return []
 
         actions = []
 
@@ -129,7 +145,7 @@ class FileActionFactory(object):
             # add the interactive 'open' action.  This is the
             # default/generic open action that gets run whenever someone
             # double-clicks on a file or just hits the 'Open' button
-            actions.append(InteractiveOpenAction(file, file_versions, work_area, workfiles_visible, publishes_visible))
+            actions.append(InteractiveOpenAction(file, self._file_versions, self._work_area, self._workfiles_visible, self._publishes_visible))
 
         if file.is_local:
             # if workfiles_visible and file.is_local:
@@ -139,39 +155,39 @@ class FileActionFactory(object):
             actions.append(SeparatorAction())
 
             # add the general open action - this just opens the file in-place.
-            actions.append(OpenWorkfileAction(file, file_versions, work_area))
+            actions.append(OpenWorkfileAction(file, self._file_versions, self._work_area))
 
-            if in_other_users_sandbox:
+            if self._in_other_users_sandbox:
                 # file is in another user sandbox so add appropriate actions:
-                actions.append(ContinueFromWorkFileAction(file, current_user_file_versions, work_area))
+                actions.append(ContinueFromWorkFileAction(file, self._current_user_file_versions, self._work_area))
 
-                if change_work_area and can_copy_to_work_area:
-                    actions.append(CopyAndOpenFileInCurrentWorkAreaAction(file, current_user_file_versions, work_area))
+                if self._change_work_area and self._can_copy_to_work_area:
+                    actions.append(CopyAndOpenFileInCurrentWorkAreaAction(file, self._current_user_file_versions, self._work_area))
 
             else:
                 # file isn't in a different sandbox so add regular open actions:
                 if file.editable:
                     # determine if this version is the latest:
-                    all_versions = [v for v, f in file_versions.iteritems()]
+                    all_versions = [v for v, f in self._file_versions.iteritems()]
                     max_version = max(all_versions) if all_versions else 0
                     if file.version != max_version:
-                        actions.append(ContinueFromWorkFileAction(file, file_versions, work_area))
+                        actions.append(ContinueFromWorkFileAction(file, self._file_versions, self._work_area))
 
-                if change_work_area and can_copy_to_work_area:
-                    actions.append(CopyAndOpenFileInCurrentWorkAreaAction(file, file_versions, work_area))
+                if self._change_work_area and self._can_copy_to_work_area:
+                    actions.append(CopyAndOpenFileInCurrentWorkAreaAction(file, self._file_versions, self._work_area))
 
         if file.is_published:
             # all actions available when selection is a work file:
 
             # ------------------------------------------------------------------
             actions.append(SeparatorAction())
-            actions.append(OpenPublishAction(file, file_versions, work_area))
+            actions.append(OpenPublishAction(file, self._file_versions, self._work_area))
             if file.path:
                 # file has a local path so it's possible to carry copy it to the local work area!
-                actions.append(ContinueFromPublishAction(file, current_user_file_versions, work_area))
+                actions.append(ContinueFromPublishAction(file, self._current_user_file_versions, self._work_area))
 
-                if change_work_area and can_copy_to_work_area:
-                    actions.append(CopyAndOpenPublishInCurrentWorkAreaAction(file, current_user_file_versions, work_area))
+                if self._change_work_area and self._can_copy_to_work_area:
+                    actions.append(CopyAndOpenPublishInCurrentWorkAreaAction(file, self._current_user_file_versions, self._work_area))
 
         # If we are at the first level of the menu, we will show previous versions of the current file,
         # if available.
@@ -179,54 +195,54 @@ class FileActionFactory(object):
             # ------------------------------------------------------------------
             actions.append(SeparatorAction())
             self.__append_previous_versions_actions(
-                actions, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=True
+                actions, file, pick_locals=True
             )
 
             self.__append_previous_versions_actions(
-                actions, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals=False
+                actions, file, pick_locals=False
             )
 
         # A New File can only be created from the first level of the menu.
-        if first_level and not in_other_users_sandbox:
-            if NewFileAction.can_do_new_file(work_area):
+        if first_level and not self._in_other_users_sandbox:
+            if NewFileAction.can_do_new_file(self._work_area):
                 # New file action
 
                 # ------------------------------------------------------------------
                 actions.append(SeparatorAction())
-                actions.append(NewFileAction(file, file_versions, work_area))
+                actions.append(NewFileAction(file, self._file_versions, self._work_area))
 
         # query for any custom actions:
-        custom_actions = CustomFileAction.get_action_details(file, file_versions, work_area,
-                                                             workfiles_visible, publishes_visible)
+        custom_actions = CustomFileAction.get_action_details(file, self._file_versions, self._work_area,
+                                                             self._workfiles_visible, self._publishes_visible)
         if custom_actions:
             # ------------------------------------------------------------------
             actions.append(SeparatorAction())
         for action_dict in custom_actions:
             name = action_dict.get("name")
             label = action_dict.get("caption") or name
-            custom_action = CustomFileAction(name, label, file, file_versions, work_area,
-                                             workfiles_visible, publishes_visible)
+            custom_action = CustomFileAction(name, label, file, self._file_versions, self._work_area,
+                                             self._workfiles_visible, self._publishes_visible)
             actions.append(custom_action)
 
         # finally add the 'show in' actions:
         show_in_actions = []
         if file.is_local:
-            show_in_actions.append(ShowWorkFileInFileSystemAction(file, file_versions, work_area))
+            show_in_actions.append(ShowWorkFileInFileSystemAction(file, self._file_versions, self._work_area))
         else:
-            if work_area.work_area_template:
-                show_in_actions.append(ShowWorkAreaInFileSystemAction(file, file_versions, work_area))
+            if self._work_area.work_area_template:
+                show_in_actions.append(ShowWorkAreaInFileSystemAction(file, self._file_versions, self._work_area))
 
         if file.is_published:
-            show_in_actions.append(ShowPublishInFileSystemAction(file, file_versions, work_area))
-            show_in_actions.append(ShowPublishInShotgunAction(file, file_versions, work_area))
+            show_in_actions.append(ShowPublishInFileSystemAction(file, self._file_versions, self._work_area))
+            show_in_actions.append(ShowPublishInShotgunAction(file, self._file_versions, self._work_area))
         else:
-            if work_area.publish_area_template:
-                show_in_actions.append(ShowPublishAreaInFileSystemAction(file, file_versions, work_area))
+            if self._work_area.publish_area_template:
+                show_in_actions.append(ShowPublishAreaInFileSystemAction(file, self._file_versions, self._work_area))
 
             # see if we have any publishes:
-            publish_versions = [v for v, f in file_versions.iteritems() if f.is_published]
+            publish_versions = [v for v, f in self._file_versions.iteritems() if f.is_published]
             if publish_versions:
-                show_in_actions.append(ShowLatestPublishInShotgunAction(file, file_versions, work_area))
+                show_in_actions.append(ShowLatestPublishInShotgunAction(file, self._file_versions, self._work_area))
 
         if show_in_actions:
             # ------------------------------------------------------------------
@@ -235,15 +251,11 @@ class FileActionFactory(object):
 
         return actions
 
-    def __append_previous_versions_actions(self, actions, file, work_area, file_model, workfiles_visible, publishes_visible, pick_locals):
+    def __append_previous_versions_actions(self, actions, file, pick_locals):
         """
         Retrives the list of actions for all the previous versions of a given type.
 
-        :param file: FileItem instance representing the selection in the browser.
-        :param work_area: WorkArea instance representing the context associate with the file.
-        :param file_model: A FileModel instance.
-        :param workfiles_visible: True if workfiles are visible, False otherwise.
-        :param publishes_visible: True if publishes are visible, False otherwise.
+
         :param pick_locals: True if we want to show previous actions for workfiles, False if we want them for publishes.
 
         :returns: List of Actions.
@@ -261,11 +273,7 @@ class FileActionFactory(object):
         previous_versions_actions = []
         # Gives us the last ten versions, from the latest to the earliest.
         for item in previous_versions[-1:-11:-1]:
-            version_actions = self.__get_actions(
-                item, work_area, file_model,
-                workfiles_visible, publishes_visible,
-                first_level=False
-            )
+            version_actions = self.__get_actions(item, first_level=False)
             previous_versions_actions.append(ActionGroup("Version %d" % item.version, version_actions))
 
         actions.append(

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -256,7 +256,7 @@ class FileActionFactory(object):
 
         # If there are no previous versions to show, return an empty list.
         if not previous_versions:
-            return 
+            return
 
         previous_versions_actions = []
         # Gives us the last ten versions, from the latest to the earliest.

--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -60,7 +60,7 @@ class NewFileAction(Action):
             # create folders and validate that we can save using the work template:
             try:
                 # create folders if needed:
-                NewFileAction.create_folders_if_needed(self._environment.context, self._environment.work_template)
+                FileAction.create_folders_if_needed(self._environment.context, self._environment.work_template)
                 # and double check that we can get all context fields for the work template:
                 self._environment.context.as_template_fields(self._environment.work_template, validate=True)
             except TankError, e:

--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -1,27 +1,28 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
+Action to create a new file.
 """
 
-import os
-
-import sgtk
 from sgtk import TankError
-from sgtk.platform.qt import QtCore, QtGui
+from sgtk.platform.qt import QtGui
 
 from .file_action import FileAction
+from .action import Action
 from ..scene_operation import prepare_new_scene, reset_current_scene, NEW_FILE_ACTION
 
-class NewFileAction(FileAction):
+
+class NewFileAction(Action):
     """
+    This action creates a new file in the given environment.
     """
 
     @staticmethod
@@ -30,22 +31,27 @@ class NewFileAction(FileAction):
         Do some validation to see if it's possible to
         start a new file with the selected context.
         """
-        can_do_new = (env.context != None 
+        can_do_new = (env.context is not None
                       and (env.context.entity or env.context.project)
-                      and env.work_area_template != None)
+                      and env.work_area_template is not None)
         return can_do_new
 
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, environment):
         """
+        Constructor.
+
+        :param environment: A WorkArea instance of where the new file will go.
         """
-        FileAction.__init__(self, "New File", file, file_versions, environment)
+        Action.__init__(self, "New File")
+        self._environment = environment
 
     def execute(self, parent_ui):
         """
-        Perform a new-scene operation initialized with
-        the current context
+        Perform a new-scene operation initialized with the current context.
+
+        :param parent_ui: Parent dialog executing this action.
         """
-        if not NewFileAction.can_do_new_file(self.environment):
+        if not NewFileAction.can_do_new_file(self._environment):
             # should never get here as the new button in the UI should
             # be disabled!
             return False
@@ -54,28 +60,28 @@ class NewFileAction(FileAction):
             # create folders and validate that we can save using the work template:
             try:
                 # create folders if needed:
-                NewFileAction.create_folders_if_needed(self.environment.context, self.environment.work_template)
+                NewFileAction.create_folders_if_needed(self._environment.context, self._environment.work_template)
                 # and double check that we can get all context fields for the work template:
-                self.environment.context.as_template_fields(self.environment.work_template, validate=True)
+                self._environment.context.as_template_fields(self._environment.work_template, validate=True)
             except TankError, e:
-                # log the original exception (useful for tracking down the problem) 
+                # log the original exception (useful for tracking down the problem)
                 self._app.log_exception("Unable to resolve template fields after folder creation!")
                 # and raise a new, clearer exception for this specific use case:
                 raise TankError("Unable to resolve template fields after folder creation!  This could mean "
                                 "there is a mismatch between your folder schema and templates.  Please email "
-                                "support@shotgunsoftware.com if you need help fixing this.") 
+                                "support@shotgunsoftware.com if you need help fixing this.")
 
             # reset the current scene:
-            if not reset_current_scene(self._app, NEW_FILE_ACTION, self.environment.context):
+            if not reset_current_scene(self._app, NEW_FILE_ACTION, self._environment.context):
                 self._app.log_debug("Unable to perform New Scene operation after failing to reset scene!")
                 return False
-    
+
             # prepare the new scene:
-            prepare_new_scene(self._app, NEW_FILE_ACTION, self.environment.context)
-    
-            if not self.environment.context == self._app.context:
+            prepare_new_scene(self._app, NEW_FILE_ACTION, self._environment.context)
+
+            if not self._environment.context == self._app.context:
                 # restart the engine with the new context
-                FileAction.restart_engine(self.environment.context)
+                FileAction.restart_engine(self._environment.context)
 
         except Exception, e:
             error_title = "Failed to complete '%s' action" % self.label
@@ -84,4 +90,3 @@ class NewFileAction(FileAction):
             return False
 
         return True
-

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -14,7 +14,7 @@ so that they can choose one to open
 """
 
 import sgtk
-from sgtk.platform.qt import QtCore, QtGui
+from sgtk.platform.qt import QtGui
 
 from .actions.file_action_factory import FileActionFactory
 from .actions.action import SeparatorAction, ActionGroup
@@ -25,9 +25,7 @@ from .file_form_base import FileFormBase
 from .ui.file_open_form import Ui_FileOpenForm
 
 from .work_area import WorkArea
-from .framework_qtwidgets import Breadcrumb
 
-from .user_cache import g_user_cache
 
 class FileOpenForm(FileFormBase):
     """
@@ -37,28 +35,28 @@ class FileOpenForm(FileFormBase):
     @property
     def exit_code(self):
         return self._exit_code
-    
+
     def __init__(self, parent=None):
         """
         Construction
         """
         app = sgtk.platform.current_bundle()
-        
+
         FileFormBase.__init__(self, parent)
-        
+
         self._exit_code = QtGui.QDialog.Rejected
-        
+
         self._new_file_env = None
         self._default_open_action = None
-        
+
         self._navigating = False
-        
+
         # create the action factory - this is used to generate actions
         # for the selected file
         self._file_action_factory = FileActionFactory()
-        
+
         try:
-            # doing this inside a try-except to ensure any exceptions raised don't 
+            # doing this inside a try-except to ensure any exceptions raised don't
             # break the UI and crash the dcc horribly!
             self._do_init()
         except:
@@ -124,7 +122,7 @@ class FileOpenForm(FileFormBase):
         """
         env_details = None
         if entity:
-            # (AD) - we need to build a context and construct the environment details 
+            # (AD) - we need to build a context and construct the environment details
             # instance for it but this may be slow enough that we should cache it!
             # Keep an eye on it and consider threading if it's noticeably slow!
             app = sgtk.platform.current_bundle()
@@ -137,7 +135,7 @@ class FileOpenForm(FileFormBase):
             destination_label = breadcrumbs[-1].label if breadcrumbs else "..."
             self._ui.nav.add_destination(destination_label, breadcrumbs)
         self._ui.breadcrumbs.set(breadcrumbs)
-    
+
     def _on_browser_file_double_clicked(self, file, env):
         """
         """
@@ -208,7 +206,7 @@ class FileOpenForm(FileFormBase):
             self._new_file_env = env
         else:
             self._new_file_env = None
-        self._ui.new_file_btn.setEnabled(self._new_file_env != None)
+        self._ui.new_file_btn.setEnabled(self._new_file_env is not None)
 
     def _on_browser_context_menu_requested(self, file, env, pnt):
         """
@@ -233,20 +231,30 @@ class FileOpenForm(FileFormBase):
 
     def _get_available_file_actions(self, file, env):
         """
+        Retrieves the actions for a given file.
+
+        :param file: FileItem to retrieve the actions for.
+        :param env: WorkArea instance representing the context for this particular file.
+
+        :returns: List of Actions.
         """
         if not file or not env:
             return []
         file_actions = self._file_action_factory.get_actions(
-                                        file,
-                                        env,
-                                        self._file_model, 
-                                        workfiles_visible=self._ui.browser.work_files_visible, 
-                                        publishes_visible=self._ui.browser.publishes_visible
-                                        )
+            file,
+            env,
+            self._file_model,
+            workfiles_visible=self._ui.browser.work_files_visible,
+            publishes_visible=self._ui.browser.publishes_visible
+        )
         return file_actions
 
     def _populate_open_menu(self, menu, file_actions):
         """
+        Creates menu entries based on a list of file actions.
+
+        :param menu: Target menu for the entries.
+        :param file_actions: List of Actions to add under the menu.
         """
         add_separators = False
         for action in file_actions:
@@ -257,10 +265,9 @@ class FileOpenForm(FileFormBase):
                 # never more than one!
                 add_separators = False
             elif isinstance(action, ActionGroup):
+                # This is an action group, so we'll add the entries in a sub-menu.
                 self._populate_open_menu(menu.addMenu(action.label), action.actions)
-                # ensure that we only add separators after at least one action item and
-                # never more than one!
-                add_separators = False
+                add_separators = True
             else:
                 q_action = QtGui.QAction(action.label, menu)
                 slot = lambda a=action: self._perform_action(a)
@@ -306,7 +313,7 @@ class FileOpenForm(FileFormBase):
         # some debug:
         app = sgtk.platform.current_bundle()
         if isinstance(action, FileAction) and action.file:
-            app.log_debug("Performing action '%s' on file '%s, v%03d'" 
+            app.log_debug("Performing action '%s' on file '%s, v%03d'"
                           % (action.label, action.file.name, action.file.version))
         else:
             app.log_debug("Performing action '%s'" % action.label)
@@ -322,9 +329,3 @@ class FileOpenForm(FileFormBase):
             # refresh all models in case something changed as a result of
             # the action (especially important with custom actions):
             self._refresh_all_async()
-
-
-
-
-
-

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -234,8 +234,9 @@ class FileOpenForm(FileFormBase):
 
         :returns: List of Actions.
         """
-        if not file or not env:
+        if not file or not env or not self._file_model:
             return []
+
         file_actions = FileActionFactory(
             file,
             env,

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -225,25 +225,24 @@ class FileOpenForm(FileFormBase):
         # finally, show the context menu:
         context_menu.exec_(pnt)
 
-    def _get_available_file_actions(self, file, env):
+    def _get_available_file_actions(self, file_item, env):
         """
         Retrieves the actions for a given file.
 
-        :param file: FileItem to retrieve the actions for.
+        :param file_item: FileItem to retrieve the actions for.
         :param env: WorkArea instance representing the context for this particular file.
 
         :returns: List of Actions.
         """
-        if not file or not env or not self._file_model:
+        if not file_item or not env or not self._file_model:
             return []
 
         file_actions = FileActionFactory(
-            file,
             env,
             self._file_model,
             workfiles_visible=self._ui.browser.work_files_visible,
             publishes_visible=self._ui.browser.publishes_visible
-        ).get_actions()
+        ).get_actions(file_item)
         return file_actions
 
     def _populate_open_menu(self, menu, file_actions):

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -17,7 +17,7 @@ import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
 from .actions.file_action_factory import FileActionFactory
-from .actions.action import SeparatorAction
+from .actions.action import SeparatorAction, ActionGroup
 from .actions.file_action import FileAction
 from .actions.new_file_action import NewFileAction
 
@@ -253,7 +253,11 @@ class FileOpenForm(FileFormBase):
             if isinstance(action, SeparatorAction):
                 if add_separators:
                     menu.addSeparator()
-                    
+                # ensure that we only add separators after at least one action item and
+                # never more than one!
+                add_separators = False
+            elif isinstance(action, ActionGroup):
+                self._populate_open_menu(menu.addMenu(action.label), action.actions)
                 # ensure that we only add separators after at least one action item and
                 # never more than one!
                 add_separators = False
@@ -262,8 +266,8 @@ class FileOpenForm(FileFormBase):
                 slot = lambda a=action: self._perform_action(a)
                 q_action.triggered[()].connect(slot)
                 menu.addAction(q_action)
-                add_separators = True      
-        
+                add_separators = True
+
     def _on_open(self):
         """
         """

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -51,10 +51,6 @@ class FileOpenForm(FileFormBase):
 
         self._navigating = False
 
-        # create the action factory - this is used to generate actions
-        # for the selected file
-        self._file_action_factory = FileActionFactory()
-
         try:
             # doing this inside a try-except to ensure any exceptions raised don't
             # break the UI and crash the dcc horribly!
@@ -240,13 +236,13 @@ class FileOpenForm(FileFormBase):
         """
         if not file or not env:
             return []
-        file_actions = self._file_action_factory.get_actions(
+        file_actions = FileActionFactory(
             file,
             env,
             self._file_model,
             workfiles_visible=self._ui.browser.work_files_visible,
             publishes_visible=self._ui.browser.publishes_visible
-        )
+        ).get_actions()
         return file_actions
 
     def _populate_open_menu(self, menu, file_actions):

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -294,7 +294,7 @@ class FileOpenForm(FileFormBase):
         if not self._new_file_env or not NewFileAction.can_do_new_file(self._new_file_env):
             return
 
-        new_file_action = NewFileAction(None, None, self._new_file_env)
+        new_file_action = NewFileAction(self._new_file_env)
 
         # perform the action - this may result in the UI being closed so don't do
         # anything after this call!


### PR DESCRIPTION
- Allows the user to open previous versions of the current selection in the file browser. The items shown in the sub-menu are the same that you would have gotten if you had clicked directly on that specific version in the "All versions" mode.
- Added documentation around the action system.
- These files were mostly PEP-8, I couldn't resist fixing them for good. :)