### PR TITLE
For #31040, New Task grayed out on entities that don't support Tasks.

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,4 +124,14 @@ class DebugWrapperShotgun(object):
         data = self._sg.insert(*args, **kwargs)
         self._log_fn("SG API insert end")
         return data
-    
+
+    def __getattr__(self, name):
+        """
+        Invoked when an attribute is not found on this instance, this will retrieve the attribute
+        on the wrapped Shotgun instance.
+
+        :param name: Name of the attribute to retrieve.
+
+        :returns: The attribute matching the given name.
+        """
+        return getattr(self._sg, name)


### PR DESCRIPTION
This disables the New Task button when the current selection in the entity view doesn't support task creation. Note that task themselves enable the button since they can trace back to an entity that supports Task.