### PR TITLE
For #30799, non modal dialog in all DCCs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,18 +1,19 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Multi Work Files 2.  
+Multi Work Files 2.
 Provides File Open/Save functionality for Work Files
 """
 import sgtk
+
 
 class MultiWorkFiles(sgtk.platform.Application):
 
@@ -21,6 +22,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         Called as the application is being initialized
         """
         self._tk_multi_workfiles = self.import_module("tk_multi_workfiles")
+        self.__is_pyside_unstable = None
 
         application_has_scenes = True
         if self.engine.name == "tk-mari":
@@ -36,7 +38,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         # Process auto startup options - but only on certain supported platforms
         # because of the way QT inits and connects to different host applications
         # differently, in conjunction with the 'boot' process in different tools,
-        # the behaviour can be very different.  
+        # the behaviour can be very different.
         #
         # currently, we have done QA on the following engines:
         SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax"]
@@ -76,25 +78,73 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         self._tk_multi_workfiles.WorkFiles.show_file_save_dlg()
 
+    def _is_pyside_unstable(self):
+        """
+        Returns if a given DCC has been shown to be unstable with the workfiles
+        app due to certain versions of Python and PySide. Right now, we're only
+        aware of Nuke 6, so we'll filter for that.
+        """
+        if self.__is_pyside_unstable is not None:
+            return self.__is_pyside_unstable
+        try:
+            import nuke
+        except ImportError:
+            self.__is_pyside_unstable = False
+        else:
+            self.__is_pyside_unstable = nuke.env.get("NukeVersionMajor") <= 7
+
+        return self.__is_pyside_unstable
+
+    @property
+    def use_modal_dialog(self):
+        """
+        Flag indicating if the dialogs should be modal.
+
+        :returns: True if modal is required, False otherwise.
+        """
+        # Debug dialogs need to be modal.
+        # Unstable PySide version need to be modal
+        return self.use_debug_dialog or self.use_managed_gc
+
+    @property
+    def use_managed_gc(self):
+        """
+        Flag indicating if the dialogs need managed garbage collection.
+
+        :returns: True if managed garbage collection is required, False otherwise.
+        """
+        return self._is_pyside_unstable()
+
+    @property
+    def use_debug_dialog(self):
+        """
+        Flag indicating if the dialogs should be invoked in debug mode. In debug
+        mode the dialog will be modal and leaked PySide objects will be reported
+        after the dialog is closed.
+
+        :returns: True if the debug_dialog setting is True, False otherwise.
+        """
+        return self.get_setting("debug_dialog", False)
+
     @property
     def shotgun(self):
         """
-        Subclassing of the shotgun property on the app base class. 
-        This is a temporary arrangement to be able to time some of the shotgun calls. 
+        Subclassing of the shotgun property on the app base class.
+        This is a temporary arrangement to be able to time some of the shotgun calls.
         """
         # get the real shotgun from the application base class
         app_shotgun = sgtk.platform.Application.shotgun.fget(self)
         # return a wrapper back which produces debug logging
         return DebugWrapperShotgun(app_shotgun, self.log_debug)
-        
-        
+
+
 class DebugWrapperShotgun(object):
-    
+
     def __init__(self, sg_instance, log_fn):
         self._sg = sg_instance
         self._log_fn = log_fn
         self.config = sg_instance.config
-        
+
     def find(self, *args, **kwargs):
         self._log_fn("SG API find start: %s %s" % (args, kwargs))
         data = self._sg.find(*args, **kwargs)
@@ -124,4 +174,3 @@ class DebugWrapperShotgun(object):
         data = self._sg.insert(*args, **kwargs)
         self._log_fn("SG API insert end")
         return data
-    

--- a/app.py
+++ b/app.py
@@ -87,6 +87,8 @@ class MultiWorkFiles(sgtk.platform.Application):
         if self.__is_pyside_unstable is not None:
             return self.__is_pyside_unstable
         try:
+            # we could go for the engine name, but we are not guaranteed that it will necessarily
+            # be ours.
             import nuke
         except ImportError:
             self.__is_pyside_unstable = False

--- a/app.py
+++ b/app.py
@@ -78,45 +78,6 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         self._tk_multi_workfiles.WorkFiles.show_file_save_dlg()
 
-    def _is_pyside_unstable(self):
-        """
-        Returns if a given DCC has been shown to be unstable with the workfiles
-        app due to certain versions of Python and PySide. Right now, we're only
-        aware of Nuke 6, so we'll filter for that.
-        """
-        if self.__is_pyside_unstable is not None:
-            return self.__is_pyside_unstable
-        try:
-            # we could go for the engine name, but we are not guaranteed that it will necessarily
-            # be ours.
-            import nuke
-        except ImportError:
-            self.__is_pyside_unstable = False
-        else:
-            self.__is_pyside_unstable = nuke.env.get("NukeVersionMajor") <= 7
-
-        return self.__is_pyside_unstable
-
-    @property
-    def use_modal_dialog(self):
-        """
-        Flag indicating if the dialogs should be modal.
-
-        :returns: True if modal is required, False otherwise.
-        """
-        # Debug dialogs need to be modal.
-        # Unstable PySide version need to be modal
-        return self.use_debug_dialog or self.use_managed_gc
-
-    @property
-    def use_managed_gc(self):
-        """
-        Flag indicating if the dialogs need managed garbage collection.
-
-        :returns: True if managed garbage collection is required, False otherwise.
-        """
-        return self._is_pyside_unstable()
-
     @property
     def use_debug_dialog(self):
         """

--- a/python/tk_multi_workfiles/__init__.py
+++ b/python/tk_multi_workfiles/__init__.py
@@ -9,4 +9,5 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .work_files import WorkFiles
+# Leaving this in to make it easier to test the dialogs through scripting.
 from .file_open_form import FileOpenForm

--- a/python/tk_multi_workfiles/__init__.py
+++ b/python/tk_multi_workfiles/__init__.py
@@ -9,3 +9,4 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .work_files import WorkFiles
+from .file_open_form import FileOpenForm

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -22,7 +22,7 @@ ShotgunEntityModel = shotgun_model.ShotgunEntityModel
 
 from ..ui.entity_tree_form import Ui_EntityTreeForm
 from .entity_tree_proxy_model import EntityTreeProxyModel
-from ..framework_qtwidgets import Breadcrumb, ShotgunModelOverlayWidget
+from ..framework_qtwidgets import Breadcrumb
 from ..util import get_model_data, get_model_str, map_to_source, get_source_model, monitor_qobject_lifetime
 
 class EntityTreeForm(QtGui.QWidget):
@@ -90,12 +90,7 @@ class EntityTreeForm(QtGui.QWidget):
         self._ui.entity_tree.expanded.connect(self._on_item_expanded)
         self._ui.entity_tree.collapsed.connect(self._on_item_collapsed)
 
-        # create the overlay 'busy' widget that will be displayed when the model is reset:
-        self._overlay_widget = ShotgunModelOverlayWidget(None, self._ui.entity_tree)
-
         if entity_model:
-            # connect the overlay widget:
-            self._overlay_widget.set_model(entity_model)
 
             if True:
                 # create a filter proxy model between the source model and the task tree view:
@@ -129,11 +124,6 @@ class EntityTreeForm(QtGui.QWidget):
             self._expanded_items = set()
             self._auto_expanded_root_items = set()
 
-            # detach the overlay widget:
-            if self._overlay_widget:
-                self._overlay_widget.set_model(None)
-                self._overlay_widget = None
-
             # clear the selection:
             if self._ui.entity_tree.selectionModel():
                 self._ui.entity_tree.selectionModel().clear()
@@ -144,7 +134,6 @@ class EntityTreeForm(QtGui.QWidget):
                 self._ui.entity_tree.setModel(None)
                 if isinstance(view_model, EntityTreeProxyModel):
                     view_model.setSourceModel(None)
-                    view_model.deleteLater()
         finally:
             self.blockSignals(signals_blocked)
 

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -595,7 +595,6 @@ class AsyncFileFinder(FileFinder):
         self._searches = {}
         for publish_model in self._available_publish_models:
             publish_model.destroy()
-            publish_model.deleteLater()
         self._available_publish_models = []
 
         # and shut down the task manager
@@ -641,7 +640,7 @@ class AsyncFileFinder(FileFinder):
             publish_model = self._available_publish_models.pop(0)
         else:
             # create a new model:
-            publish_model = SgPublishedFilesModel(search_id, self._bg_task_manager, parent=None)
+            publish_model = SgPublishedFilesModel(search_id, self._bg_task_manager, parent=self)
             publish_model.data_refreshed.connect(self._on_publish_model_refreshed)
             publish_model.data_refresh_fail.connect(self._on_publish_model_refresh_failed)
             monitor_qobject_lifetime(publish_model, "Finder publish model")

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -32,6 +32,7 @@ from .work_area import WorkArea
 from .actions.new_task_action import NewTaskAction
 from .user_cache import g_user_cache
 from .util import monitor_qobject_lifetime
+
 
 class FileFormBase(QtGui.QWidget):
     """
@@ -82,21 +83,15 @@ class FileFormBase(QtGui.QWidget):
         # clear up the various data models:
         if self._file_model:
             self._file_model.destroy()
-            self._file_model.deleteLater()
-            self._file_model = None
         if self._my_tasks_model:
             self._my_tasks_model.destroy()
-            self._my_tasks_model.deleteLater()
-            self._my_tasks_model = None
         for _, model in self._entity_models:
             model.destroy()
-            model.deleteLater()
         self._entity_models = []
 
         # and shut down the task manager
         if self._bg_task_manager:
             self._bg_task_manager.shut_down()
-            self._bg_task_manager.deleteLater()
             self._bg_task_manager = None
 
         return QtGui.QWidget.closeEvent(self, event)
@@ -123,13 +118,13 @@ class FileFormBase(QtGui.QWidget):
 
         # create the model:
         model = MyTasksModel(app.context.project,
-                             g_user_cache.current_user, 
-                             extra_display_fields, 
-                             parent = None, 
-                             bg_task_manager = self._bg_task_manager)
+                             g_user_cache.current_user,
+                             extra_display_fields,
+                             parent=self,
+                             bg_task_manager=self._bg_task_manager)
         monitor_qobject_lifetime(model, "My Tasks Model")
         model.async_refresh()
-        return model 
+        return model
 
     def _build_entity_models(self):
         """
@@ -151,12 +146,12 @@ class FileFormBase(QtGui.QWidget):
 
             # resolve any magic tokens in the filter
             # Note, we always filter on the current project as the app needs templates
-            # in the config to be able to find files and there is currently no way to 
+            # in the config to be able to find files and there is currently no way to
             # get these from a config belonging to a different project!
             resolved_filters = []
 
             # we always filter within the current project as it's not currently possible
-            # to manage work files across projects (as we can't access the other project's 
+            # to manage work files across projects (as we can't access the other project's
             # templates and folder schema).
             #
             # Note that this currently doesn't work for non-project entities!
@@ -194,7 +189,7 @@ class FileFormBase(QtGui.QWidget):
             if entity_type == "Task":
                 fields += ["step", "entity", "content", "sg_status_list", "task_assignees"]
 
-            model = ShotgunEntityModel(entity_type, resolved_filters, hierarchy, fields, parent=None, 
+            model = ShotgunEntityModel(entity_type, resolved_filters, hierarchy, fields, parent=self,
                                        bg_task_manager=self._bg_task_manager)
             monitor_qobject_lifetime(model, "Entity Model")
             entity_models.append((caption, model))
@@ -209,7 +204,7 @@ class FileFormBase(QtGui.QWidget):
         :returns:   A FileModel instance that represents all the files found for a set of entities
                     and users.
         """
-        file_model = FileModel(self._bg_task_manager, parent=None)
+        file_model = FileModel(self._bg_task_manager, parent=self)
         monitor_qobject_lifetime(file_model, "File Model")
         return file_model
 
@@ -300,7 +295,7 @@ class FileFormBase(QtGui.QWidget):
         template_fields = base_template.get_fields(path)
         fields = dict(chain(template_fields.iteritems(), fields.iteritems()))
 
-        file_key = FileItem.build_file_key(fields, work_area.work_template, 
+        file_key = FileItem.build_file_key(fields, work_area.work_template,
                                            work_area.version_compare_ignore_fields)
 
         # extract details from the fields:
@@ -319,7 +314,3 @@ class FileFormBase(QtGui.QWidget):
                              publish_details = fields if is_publish else None)
 
         return file_item
-
-
-
-    

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -122,7 +122,6 @@ class FileListForm(QtGui.QWidget):
                 self._ui.file_details_view.setModel(None)
                 if isinstance(view_model, FileProxyModel):
                     view_model.setSourceModel(None)
-                    view_model.deleteLater()
                     view_model = None
 
             # detach and clean up the item delegate:

--- a/python/tk_multi_workfiles/file_list/user_filter_menu.py
+++ b/python/tk_multi_workfiles/file_list/user_filter_menu.py
@@ -47,7 +47,7 @@ class UserFilterMenu(QtGui.QMenu):
 
         self._current_user_action = QtGui.QAction("Show My Files", self)
         self._current_user_action.setCheckable(True)
-        toggled_slot = lambda toggled, uid=self._current_user_id: self._on_user_toggled(uid, toggled)
+        toggled_slot = lambda toggled: self._on_user_toggled(self._current_user_id, toggled)
         self._current_user_action.toggled.connect(toggled_slot)
         self.addAction(self._current_user_action)
 

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -67,7 +67,7 @@ class FileOpenForm(FileFormBase):
         self._ui = Ui_FileOpenForm()
         self._ui.setupUi(self)
 
-        # start by dissabling buttons:
+        # start by disabling buttons:
         self._ui.open_btn.setEnabled(False)
         self._ui.open_options_btn.setEnabled(False)
 

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -302,7 +302,7 @@ class FileSaveForm(FileFormBase):
         if not env or not env.context:
             raise TankError("Please select a work area to save into...")
         elif not env.work_template:
-            raise TankError("Unable to save into this work area.  Please select a different work area!")
+            raise TankError("The working directory has not been defined for this work area.  Please select another work area.")
 
         # build the fields dictionary from the environment:
         fields = {}

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -40,10 +40,6 @@ GroupWidgetBase = views.GroupWidgetBase
 GroupedListViewItemDelegate = views.GroupedListViewItemDelegate
 WidgetDelegate = views.WidgetDelegate
 
-# overlay widget:
-overlay_module = sgtk.platform.import_framework("tk-framework-qtwidgets", "overlay_widget")
-ShotgunModelOverlayWidget = overlay_module.ShotgunModelOverlayWidget
-
 # hierarchical filtering proxy model:
 models = sgtk.platform.import_framework("tk-framework-qtwidgets", "models")
 HierarchicalFilteringProxyModel = models.HierarchicalFilteringProxyModel

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -20,7 +20,7 @@ from sgtk.platform.qt import QtCore, QtGui
 from .my_task_item_delegate import MyTaskItemDelegate
 from ..entity_proxy_model import EntityProxyModel
 from ..ui.my_tasks_form import Ui_MyTasksForm
-from ..framework_qtwidgets import Breadcrumb, ShotgunModelOverlayWidget
+from ..framework_qtwidgets import Breadcrumb
 from ..util import map_to_source, get_source_model, monitor_qobject_lifetime
 
 class MyTasksForm(QtGui.QWidget):
@@ -71,14 +71,8 @@ class MyTasksForm(QtGui.QWidget):
         else:
             self._ui.new_task_btn.hide()
 
-        # create the overlay 'busy' widget - this is displayed initiallt when there is nothing
-        # in the model and it is populating itself from Shotgun
-        self._overlay_widget = ShotgunModelOverlayWidget(None, self._ui.task_tree)
-
         self._item_delegate = None
         if tasks_model:
-            # connect the overlay widget:
-            self._overlay_widget.set_model(tasks_model)
 
             if True:
                 # create a filter proxy model between the source model and the task tree view:
@@ -114,11 +108,6 @@ class MyTasksForm(QtGui.QWidget):
             # clear any references:
             self._current_item_ref = None
 
-            # detach the overlay widget:
-            if self._overlay_widget:
-                self._overlay_widget.set_model(None)
-                self._overlay_widget = None
-
             # clear the selection:
             if self._ui.task_tree.selectionModel():
                 self._ui.task_tree.selectionModel().clear()
@@ -129,7 +118,6 @@ class MyTasksForm(QtGui.QWidget):
                 self._ui.task_tree.setModel(None)
                 if isinstance(view_model, EntityProxyModel):
                     view_model.setSourceModel(None)
-                    view_model.deleteLater()
 
             # detach and clean up the item delegate:
             self._ui.task_tree.setItemDelegate(None)

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -163,7 +163,7 @@ class WorkFiles(object):
         """
         handler = WorkFiles()
         from .file_open_form import FileOpenForm
-        handler._show_file_dlg_modally("File Open", FileOpenForm)
+        handler._show_file_dlg("File Open", FileOpenForm)
 
     @staticmethod
     def show_file_save_dlg():
@@ -172,7 +172,7 @@ class WorkFiles(object):
         """
         handler = WorkFiles()
         from .file_save_form import FileSaveForm
-        handler._show_file_dlg_modally("File Save", FileSaveForm)
+        handler._show_file_dlg("File Save", FileSaveForm)
 
     def _show_file_dlg(self, dlg_name, form):
         """

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -17,70 +17,6 @@ from sgtk.platform.qt import QtCore
 from .util import report_non_destroyed_qobjects
 
 
-class TimedGc(QtCore.QObject):
-    """
-    Helper class that disables cyclic garbage collection and runs it periodically
-    on the main thread through use of a QTimer.  This is used to avoid Qt objects being
-    gc'd from non-main threads which was causing instability older PySide/Python
-    versions (Python 2.6 in Nuke 6 being one example).
-    """
-    def __init__(self, parent=None):
-        """
-        Construction
-
-        :param parent:  The parent QObject for this instance
-        """
-        QtCore.QObject.__init__(self, parent)
-        self._timer = QtCore.QTimer(self)
-        self._timer.timeout.connect(self._do_gc_collect)
-        self._gc_enabled = False
-
-    def start(self):
-        """
-        Disable the gc and start the timer
-        """
-        self._gc_enabled = gc.isenabled()
-        if self._gc_enabled:
-            gc.disable()
-            self._timer.start(10000)
-
-    def stop(self):
-        """
-        Stop the timer and re-enable the gc
-        """
-        self._timer.stop()
-        if self._gc_enabled:
-            # re-enable garbage collection:
-            gc.enable()
-        # and do one last collect
-        gc.collect()
-
-    def _do_gc_collect(self):
-        """
-        Slot triggered by the timer's timeout signal to perform
-        a gc collect at the timed interval.
-        """
-        gc.collect()
-
-
-def managed_gc(func):
-    """
-    Decorator function to disable cyclic garbage collection whilst the wrapped function is run.
-    Whilst it is running, gc.collect() is instead run on a timer - this ensure that it always
-    runs in the main thread to avoid gc issues with PySide/Qt objects being deleted from another,
-    non-main thread.
-    """
-    def wrapper(*args, **kwargs):
-        timed_gc = TimedGc()
-        timed_gc.start()
-        try:
-            return func(*args, **kwargs)
-        finally:
-            timed_gc.stop()
-            timed_gc.deleteLater()
-    return wrapper
-
-
 def dbg_info(func):
     """
     Decorator function used to track memory and other useful debug information around the file-open
@@ -142,19 +78,13 @@ class WorkFiles(object):
         app.sgtk.synchronize_filesystem_structure()
         app.log_debug("Path cache up to date!")
 
-        # If we should use modal dialogs.
-        if app.use_modal_dialog:
-            self._dialog_launcher = app.engine.show_modal
+        # If the user wants to debug the dialog, show it modally and wrap it
+        # with memory leak-detection code.
+        if app.use_debug_dialog:
+            self._dialog_launcher = dbg_info(app.engine.show_modal)
         else:
             self._dialog_launcher = app.engine.show_dialog
 
-        # Output debugging information when the dialog is closed.
-        if app.use_debug_dialog:
-            self._dialog_launcher = dbg_info(self._dialog_launcher)
-
-        # Wrap the dialog with managed garbage collection.
-        if app.use_managed_gc:
-            self._dialog_launcher = managed_gc(self._dialog_launcher)
 
     @staticmethod
     def show_file_open_dlg():

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -174,9 +174,12 @@ class WorkFiles(object):
         from .file_save_form import FileSaveForm
         handler._show_file_dlg_modally("File Save", FileSaveForm)
 
-    def _show_file_dlg_modally(self, dlg_name, form):
+    def _show_file_dlg(self, dlg_name, form):
         """
-        Show a dialog modally
+        Shows the file dialog modally or not depending on the current DCC and settings.
+
+        :param dlg_name: Title of the dialog.
+        :param form: Factory for the dialog class.
         """
         app = sgtk.platform.current_bundle()
         try:


### PR DESCRIPTION
- Dialogs are not modal anymore to behave better with various DCCs who have issues displaying modal dialogs on top of ours.

- App is a lot more stable, especially in Nuke on OSX and Windows. This has been achieved by making all model related objects children of the dialog instead of relying on deleteLater to delete them. While this has stabilized the app across the board since deleteLater causes crashes in multiple DCCs, it also made the models leak in certain DCCs instead of being freed, which is hardly ideal. However, a memory leak at the moment is better than a complete DCC crash. We will look right away on a leak mitigation strategy. There's a strong smell that this leak might be related to PySide and outside our control, since children QObjects should be released by Qt automatically.

- Removed the Shotgun Model Overlay Widget which never worked with the app and might be a source of instability.