### PR TITLE
33063 Add user activity metrics calls

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -192,8 +192,6 @@ requires_shotgun_version:
 requires_core_version: "v0.17.0"
 requires_engine_version:
 
-# XXX will require core that supports metrics logging
-
 # the engines that this app can operate in:
 supported_engines: 
 

--- a/info.yml
+++ b/info.yml
@@ -190,7 +190,9 @@ description: "Using this app you can browse, open and save
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.17.0"
-requires_engine_version: 
+requires_engine_version:
+
+# XXX will require core that supports metrics logging
 
 # the engines that this app can operate in:
 supported_engines: 

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -236,7 +236,11 @@ class InteractiveOpenAction(OpenFileAction):
                     src_path = work_path
                     work_path = local_path
 
-        self._app.log_metric("Open workfile")
+        try:
+            self._app.log_metric("Open workfile")
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
 
@@ -330,7 +334,11 @@ class InteractiveOpenAction(OpenFileAction):
                 self._app.log_exception("Failed to resolve work file path from publish path: %s" % src_path)
                 return False
 
-        self._app.log_metric("Open published file")
+        try:
+            self._app.log_metric("Open published file")
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
         

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -236,6 +236,8 @@ class InteractiveOpenAction(OpenFileAction):
                     src_path = work_path
                     work_path = local_path
 
+        self._app.log_metric("Open workfile")
+
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
 
     def _open_previous_publish(self, file, env, parent_ui):
@@ -327,6 +329,8 @@ class InteractiveOpenAction(OpenFileAction):
                                        "Unable to open file!" % (src_path, e)))
                 self._app.log_exception("Failed to resolve work file path from publish path: %s" % src_path)
                 return False
+
+        self._app.log_metric("Open published file")
 
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
         

--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -88,5 +88,7 @@ class NewFileAction(Action):
             QtGui.QMessageBox.information(parent_ui, "%s!" % error_title, "%s:\n\n%s!" % (error_title, e))
             self._app.log_exception(error_title)
             return False
+        else:
+            self._app.log_metric("New file")
 
         return True

--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -89,6 +89,10 @@ class NewFileAction(Action):
             self._app.log_exception(error_title)
             return False
         else:
-            self._app.log_metric("New file")
+            try:
+                self._app.log_metric("New file")
+            except:
+                # ignore all errors. ex: using a core that doesn't support metrics
+                pass
 
         return True

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -43,7 +43,11 @@ class SaveAsFileAction(FileAction):
                 self._app.log_exception("Failed to change the work area to %s!" % self.environment.context)
                 return False
             else:
-                self._app.log_metric("Save as to diff workarea")
+                try:
+                    self._app.log_metric("Save as to diff workarea")
+                except:
+                    # ignore all errors. ex: using a core that doesn't support metrics
+                    pass
 
         # and save the current file as the new path:
         try:

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -42,6 +42,8 @@ class SaveAsFileAction(FileAction):
                     % (self.environment.context, e))
                 self._app.log_exception("Failed to change the work area to %s!" % self.environment.context)
                 return False
+            else:
+                self._app.log_metric("Save as to diff workarea")
 
         # and save the current file as the new path:
         try:


### PR DESCRIPTION
The calls log the metrics internally and ignore any errors. This prevents the need to force the app/fw users to update to a new core that supports metrics. When a supported core is updated, the metrics will be logged.