### PR TITLE
For #34391, workfiles2 in nuke studio

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,16 +24,13 @@ class MultiWorkFiles(sgtk.platform.Application):
         self._tk_multi_workfiles = self.import_module("tk_multi_workfiles")
         self.__is_pyside_unstable = None
 
-        application_has_scenes = True
         if self.engine.name == "tk-mari":
             # Mari doesn't have the concept of a current scene so this app shouldn't
             # provide any commands!
             return
 
-        # register commands:
-        if application_has_scenes:
-            self.engine.register_command("File Open...", self.show_file_open_dlg, {"short_name":"file_open"})
-            self.engine.register_command("File Save...", self.show_file_save_dlg, {"short_name":"file_save"})
+        self.engine.register_command("File Open...", self.show_file_open_dlg, {"short_name":"file_open"})
+        self.engine.register_command("File Save...", self.show_file_save_dlg, {"short_name":"file_save"})
 
         # Process auto startup options - but only on certain supported platforms
         # because of the way QT inits and connects to different host applications

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         if self.engine.name == "tk-mari":
             # Mari doesn't have the concept of a current scene so this app shouldn't
             # provide any commands!
-            application_has_scenes = False
+            return
 
         # register commands:
         if application_has_scenes:

--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -84,33 +84,6 @@ class FileAction(Action):
         if create_folders:
             FileAction.create_folders(ctx)
 
-
-    @staticmethod
-    def restart_engine(ctx):
-        """
-        Set context to the new context.  This will
-        clear the current scene and restart the
-        current engine with the specified context
-        """
-        app = sgtk.platform.current_bundle()
-        app.log_info("Restarting the engine...")
-        
-        # restart engine:
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
-        try:
-            current_engine_name = app.engine.name
-            
-            # stop current engine:            
-            if sgtk.platform.current_engine(): 
-                sgtk.platform.current_engine().destroy()
-                
-            # start engine with new context:
-            sgtk.platform.start_engine(current_engine_name, ctx.sgtk, ctx)
-        except Exception, e:
-            raise TankError("Failed to change work area and start a new engine - %s" % e)
-        finally:
-            QtGui.QApplication.restoreOverrideCursor()
-
     @staticmethod
     def change_context(ctx):
         """
@@ -124,15 +97,9 @@ class FileAction(Action):
         # restart engine:
         QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         try:
-            # If there's an engine running, change its context. Otherwise
-            # start the engine up in the new context.
-            if sgtk.platform.current_engine(): 
-                sgtk.platform.change_context(ctx)
-                return
-
-            sgtk.platform.start_engine(current_engine_name, ctx.sgtk, ctx)
+            sgtk.platform.change_context(ctx)
         except Exception, e:
-            raise TankError("Failed to change work area and start a new engine - %s" % e)
+            raise TankError("Failed to change work area - %s" % e)
         finally:
             QtGui.QApplication.restoreOverrideCursor()
     

--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -80,7 +80,7 @@ class NewFileAction(Action):
             prepare_new_scene(self._app, NEW_FILE_ACTION, self._environment.context)
 
             if not self._environment.context == self._app.context:
-                # restart the engine with the new context
+                # Change context
                 FileAction.change_context(self._environment.context)
 
         except Exception, e:

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -110,7 +110,7 @@ class OpenFileAction(FileAction):
         # switch context:
         if not new_ctx == self._app.context:
             try:
-                # restart the engine with the new context
+                # Change the curent context.
                 FileAction.change_context(new_ctx)
             except Exception, e:
                 QtGui.QMessageBox.critical(parent_ui, "Failed to change the work area", 

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -34,7 +34,7 @@ class SaveAsFileAction(FileAction):
         # switch context:
         if not self.environment.context == self._app.context:
             try:
-                # restart the engine with the new context
+                # Change the current context
                 FileAction.change_context(self.environment.context)
             except Exception, e:
                 QtGui.QMessageBox.critical(parent_ui, "Failed to change the work area", 


### PR DESCRIPTION
Application settings detection wasn't honouring the engine instance name, which means that it was possible to switch from one engine instance to another by mistake. This caused issues with the default config with Nuke and Nuke Studio.

We're now forcing context change to happen to an engine that has the same instance name, just like in workfiles 1.

I've also removed some code that allowed to test the app by using workfiles v1 settings.