### PR TITLE
For #35335, user sandbox behaviour fix

### DIFF
--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -520,12 +520,9 @@ class BrowserForm(QtGui.QWidget):
         if isinstance(form, MyTasksForm):
             # retrieve the selected task from the form and emit a work-area changed signal:
             task, breadcrumb_trail = form.get_selection()
-            # self._emit_work_area_changed(task, breadcrumb_trail)
             self._on_selected_task_changed(task, breadcrumb_trail)
 
         elif isinstance(form, EntityTreeForm):
             # retrieve the selection from the form and emit a work-area changed signal:
             selection, breadcrumb_trail = form.get_selection()
-            # selected_entity = selection.get("entity") if selection else None
-            # self._emit_work_area_changed(selected_entity, breadcrumb_trail)
             self._on_selected_entity_changed(selection, breadcrumb_trail)

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -14,7 +14,6 @@ current work file.  Also give the user the option to select the file to save fro
 the list of current work files.
 """
 
-import itertools
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
@@ -406,15 +405,15 @@ class BrowserForm(QtGui.QWidget):
                     details.is_leaf = is_leaf
                     search_details.append(details)
 
-            # If we can enable user filtering, show or hide tje user filter widget
+            # If we can enable user filtering, show or hide the user filter widget
             # if one of the entities in the selection has sandboxes.
             if self._enable_user_filtering:
-                # Certain elements in the selection can be other things than entities,
-                # like the "Character" property in the tree view which is not an entity.
-                flat_selection = itertools.ifilter(
-                    lambda x: x is not None,
-                    [primary_entity] + [child_detail["entity"] for child_detail in children]
-                )
+                # The elementes in the selection might not always be an entity, e.g.
+                # if the user clicked the "Character" category, so filter None entities.
+                flat_selection = [child_detail["entity"] for child_detail in children if child_detail is not None]
+                if primary_entity:
+                    flat_selection.append(primary_entity)
+
                 # For each form, show the button if its content uses sandboxes.
                 for form in self._file_browser_forms:
                     if form.work_files_visible and self._uses_sandboxes(flat_selection, workfiles=True):
@@ -461,9 +460,6 @@ class BrowserForm(QtGui.QWidget):
         # Turn on or off user sandbox filter button.
         app = sgtk.platform.current_bundle()
         for entity in flat_selection:
-            if not entity:
-                continue
-
             # build a context from the search details:
             context = app.sgtk.context_from_entity_dictionary(entity)
 

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -473,6 +473,11 @@ class BrowserForm(QtGui.QWidget):
         return primary_entity
 
     def _on_uses_user_sandboxes(self, work_area):
+        """
+        Called when the file finder reports a work area that uses sandboxes.
+
+        :param work_area: WorkArea using a sandbox.
+        """
         for form in self._file_browser_forms:
             if form.work_files_visible and work_area.work_area_contains_user_sandboxes:
                 form.enable_user_filtering_widget(True)

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -182,10 +182,13 @@ class FileListForm(QtGui.QWidget):
             self._ui.all_versions_cb.hide()
             self._on_show_all_versions_toggled(False)
 
-    def enable_user_filtering(self, enable):
+    def show_user_filtering_widget(self, is_visible):
         """
+        Displays or hides the user filtering widget.
+
+        :param is_visible: If True, the user filtering widget will be shown.
         """
-        self._ui.user_filter_btn.setVisible(enable)
+        self._ui.user_filter_btn.setVisible(is_visible)
 
     def select_file(self, file_item, context):
         """

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -81,7 +81,7 @@ class FileListForm(QtGui.QWidget):
         self._ui.user_filter_btn.selected_users = self._file_filters.users
         self._ui.user_filter_btn.users_selected.connect(self._on_user_filter_btn_users_selected)
         # user filter button is hidden until needed
-        self._ui.user_filter_btn.hide()
+        self.enable_user_filtering_widget(False)
 
         self._ui.file_list_view.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
         self._ui.file_list_view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
@@ -189,6 +189,26 @@ class FileListForm(QtGui.QWidget):
         :param is_visible: If True, the user filtering widget will be shown.
         """
         self._ui.user_filter_btn.setVisible(is_visible)
+
+    def enable_user_filtering_widget(self, is_enabled):
+        """
+        Displays or hides the user filtering widget.
+
+        :param is_visible: If True, the user filtering widget will be shown.
+        """
+        if self._show_publishes and not self._show_work_files:
+            sandbox_type = "publish "
+        elif not self._show_publishes and self._show_work_files:
+            sandbox_type = "work file "
+        else:
+            sandbox_type = ""
+
+        if is_enabled:
+            self._ui.user_filter_btn.setToolTip("Click to see the list of %ssandboxes available for this context." % sandbox_type)
+        else:
+            self._ui.user_filter_btn.setToolTip("There are no %ssandboxes available for this context." % sandbox_type)
+
+        self._ui.user_filter_btn.setEnabled(is_enabled)
 
     def select_file(self, file_item, context):
         """

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -66,7 +66,6 @@ class FileListForm(QtGui.QWidget):
 
         self._show_work_files = show_work_files
         self._show_publishes = show_publishes
-        self._enable_user_filtering = True
 
         # set up the UI
         self._ui = Ui_FileListForm()
@@ -186,10 +185,7 @@ class FileListForm(QtGui.QWidget):
     def enable_user_filtering(self, enable):
         """
         """
-        self._enable_user_filtering = enable
-        if not self._enable_user_filtering:
-            # make sure user button is hidden:
-            self._ui.user_filter_btn.hide()
+        self._ui.user_filter_btn.setVisible(enable)
 
     def select_file(self, file_item, context):
         """
@@ -337,9 +333,6 @@ class FileListForm(QtGui.QWidget):
 
         :param users:   The new list of available users
         """
-        if self._enable_user_filtering and users and not self._ui.user_filter_btn.isVisible():
-            self._ui.user_filter_btn.show()
-
         # update user filter button
         self._ui.user_filter_btn.available_users = users
 

--- a/python/tk_multi_workfiles/file_list/user_filter_button.py
+++ b/python/tk_multi_workfiles/file_list/user_filter_button.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -13,19 +13,28 @@ QPushButton containing a menu that allows selection of users from a list of avai
 updates it's icon depending on the current selection in the menu.
 """
 
-import sgtk
 from sgtk.platform.qt import QtCore, QtGui
-from ..user_cache import g_user_cache
 
 from .user_filter_menu import UserFilterMenu
 
+
 class UserFilterButton(QtGui.QPushButton):
     """
+    Button that when pressed will show the list of user sandboxes available.
     """
+
     users_selected = QtCore.Signal(object)# list of users
-    
+
+    _USER_STYLE_NONE = "none"
+    _USER_STYLE_CURRENT = "current"
+    _USER_STYLE_OTHER = "other"
+    _USER_STYLE_ALL = "all"
+
     def __init__(self, parent):
         """
+        Constructor.
+
+        :param parent: Parent widget.
         """
         QtGui.QPushButton.__init__(self, parent)
 
@@ -34,47 +43,78 @@ class UserFilterButton(QtGui.QPushButton):
         self.setMenu(users_menu)
         self._update()
 
-    #@property
+    # @property
     def _get_selected_users(self):
+        """
+        Retrieves the list of selected users in the user filter menu.
+
+        :returns: List of selected users entities.
+        """
         return self.menu().selected_users
-    #selected_users.setter
+
+    # selected_users.setter
     def _set_selected_users(self, users):
+        """
+        Sets the lists of users selected in the user filter menu.
+
+        :param users: List of user entities.
+        """
         self.menu().selected_users = users
         self._update()
     selected_users = property(_get_selected_users, _set_selected_users)
 
-    #@property
+    # @property
     def _get_available_users(self):
+        """
+        Retrieves the list of users available for selection in the user filter menu.
+
+        :returns: List of available users entities.
+        """
         return self.menu().available_users
+
     # available_users.setter
     def _set_available_users(self, users):
+        """
+        Sets the list of users available for selection in the user filter menu.
+
+        :users users: List of user entities.
+        """
         self.menu().available_users = users
         self._update()
     available_users = property(_get_available_users, _set_available_users)
 
     def _on_menu_users_selected(self, users):
         """
+        Called whenever the selection changes in the user filter menu.
+
+        :params users: List of users that are selected.
         """
         self.users_selected.emit(users)
         self._update()
 
+    def setEnabled(self, is_enabled):
+        """
+        Enables or disables the widget.
+
+        :param is_enabled: If True, widget will be enabled.
+        """
+        QtGui.QPushButton.setEnabled(self, is_enabled)
+        self._update()
+
     def _update(self):
         """
+        Updates the status of the button.
         """
-        USER_STYLE_NONE = "none"
-        USER_STYLE_CURRENT = "current"
-        USER_STYLE_OTHER = "other"
-        USER_STYLE_ALL = "all"
-
         # figure out the style to use:
-        user_style = USER_STYLE_NONE
-        if self.menu().current_user_selected:
-            if self.menu().other_users_selected:
-                user_style = USER_STYLE_ALL
-            else:
-                user_style = USER_STYLE_CURRENT
-        elif self.menu().other_users_selected:
-            user_style = USER_STYLE_OTHER
+        user_style = self._USER_STYLE_NONE
+        if self.menu().isEnabled():
+            if self.menu().current_user_selected:
+                if self.menu().other_users_selected:
+                    user_style = self._USER_STYLE_ALL
+                else:
+                    user_style = self._USER_STYLE_CURRENT
+            elif self.menu().other_users_selected:
+                user_style = self._USER_STYLE_OTHER
 
         # set the property on the filter btn:
         self.setProperty("user_style", user_style)

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -132,6 +132,7 @@ class FileSaveForm(FileFormBase):
 
         # initialize the browser:
         self._ui.browser.enable_show_all_versions(False)
+        # We don't want to see other user's sandboxes, nor do we want to save in them.
         self._ui.browser.enable_user_filtering(False)
         self._ui.browser.set_models(self._my_tasks_model, self._entity_models, self._file_model)
         env = WorkArea(app.context)

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -134,7 +134,7 @@ class FileSaveForm(FileFormBase):
         # initialize the browser:
         self._ui.browser.enable_show_all_versions(False)
         # We don't want to see other user's sandboxes, nor do we want to save in them.
-        self._ui.browser.enable_user_filtering(False)
+        self._ui.browser.show_user_filtering_widget(False)
         self._ui.browser.set_models(self._my_tasks_model, self._entity_models, self._file_model)
         current_file = self._get_current_file()
         self._ui.browser.select_work_area(app.context)


### PR DESCRIPTION
The user sandbox button is now displayed as soon as a work area CAN have one and not only when there's one on disk. This makes the user experience consistent and predictable.