### PR TITLE
For #36351, gentler error reporting

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -183,9 +183,8 @@ configuration:
 requires_shotgun_fields:
 
 # More verbose description of this item 
-display_name: "Shotgun File Manager"
-description: "Using this app you can browse, open and save 
-              your Work Files and Publishes."
+display_name: "Shotgun Workfiles"
+description: "Using this app you can browse, open and save your Work Files and Publishes."
               
 # Required minimum versions for this item to run
 requires_shotgun_version:

--- a/python/tk_multi_workfiles/errors.py
+++ b/python/tk_multi_workfiles/errors.py
@@ -12,6 +12,7 @@
 Workfiles 2 related errors.
 """
 
+from .work_area import WorkArea
 from sgtk import TankError
 
 
@@ -39,7 +40,7 @@ class MissingTemplatesError(WorkfilesError):
         """
         Generates a warning for when templates are not all configured.
         """
-        if len(missing_templates) == 4:
+        if len(missing_templates) == WorkArea.NB_TEMPLATE_SETTINGS:
             return "No templates have been defined."
         else:
             # Then take every template except the last one and join them with commas.

--- a/python/tk_multi_workfiles/errors.py
+++ b/python/tk_multi_workfiles/errors.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Workfiles 2 related errors.
+"""
+
+from sgtk import TankError
+
+
+class WorkAreaError(TankError):
+    """
+    Base class for work area related errors.
+    """
+
+    @classmethod
+    def _get_user_friendly_context(cls, work_area):
+        """
+        Generates a user friendly error string about the work area's context.
+
+        :returns: Error string.
+        """
+        return "context '%s' in engine instance '%s'" % (
+            work_area.context, work_area.engine_instance_name
+        )
+
+
+class WorkAreaSettingsNotFoundError(WorkAreaError):
+    """
+    Raised when no settings for the workfiles 2 app are found in an environment.
+    """
+
+    def __init__(self, work_area):
+        """
+        Constructor.
+
+        :param work_area: Work area that raised an error.
+        """
+        WorkAreaError.__init__(
+            "Failed to find the Shotgun File Manager settings for %s.\n\n"
+            "Please ensure that the app is installed for the environment that will "
+            "be used for this work area." % (self._get_user_friendly_context())
+        )
+
+
+class UnconfiguredTemplatesError(WorkAreaError):
+    """
+    Raised when one or more templates are not configured.
+    """
+
+    def __init__(self, missing_templates, work_area):
+        """
+        Constructor.
+
+        :param missing_templates: List of templates that are missing.
+        :param work_area: Work area that raised an error.
+        """
+        if len(missing_templates) == 4:
+            self._is_partially_configured = False
+            WorkAreaError.__init__(
+                "No templates have been defined for %s. Define the templates "
+                "in your configuration to enable workfile management here." %
+                self._get_user_friendly_context(work_area)
+            )
+        else:
+            self._is_partially_configured = True
+            # Then take every template except the last one and join them with commas.
+            comma_separated_templates = missing_templates[:-1]
+            comma_separated_string = ", ".join(comma_separated_templates)
+
+            # If the string is not empty, we'll add the last missing template name.
+            if comma_separated_string:
+                missing_templates_string = "%s and %s" % (comma_separated_string, missing_templates[-1])
+            else:
+                missing_templates_string = missing_templates[0]
+
+            is_plural = len(missing_templates) > 1
+
+            WorkAreaError.__init__(
+                "The template%s %s %s not been defined for %s.\n\n"
+                "Please update your pipeline configuration." % (
+                    "s" if is_plural else "",
+                    missing_templates_string,
+                    "have" if is_plural else "has",
+                    self._get_user_friendly_context()
+                )
+            )
+
+    @property
+    def is_partially_configured(self):
+        """
+        Indicates if only some templates are missing.
+
+        :returns: True if no templates have been set, False otherwise.
+        """
+        return self._is_partially_configured

--- a/python/tk_multi_workfiles/errors.py
+++ b/python/tk_multi_workfiles/errors.py
@@ -15,42 +15,29 @@ Workfiles 2 related errors.
 from sgtk import TankError
 
 
-class WorkAreaError(TankError):
+class WorkfilesError(TankError):
     """
     Base class for work area related errors.
     """
 
-    @classmethod
-    def _get_user_friendly_context(cls, work_area):
-        """
-        Generates a user friendly error string about the work area's context.
 
-        :returns: Error string.
-        """
-        return "context '%s' in engine instance '%s'" % (
-            work_area.context, work_area.engine_instance_name
-        )
-
-
-class WorkAreaSettingsNotFoundError(WorkAreaError):
+class WorkAreaSettingsNotFoundError(WorkfilesError):
     """
     Raised when no settings for the workfiles 2 app are found in an environment.
     """
 
-    def __init__(self, work_area):
+    def __init__(self):
         """
         Constructor.
-
-        :param work_area: Work area that raised an error.
         """
-        WorkAreaError.__init__(
+        WorkfilesError.__init__(
             self,
             "Add the Shotgun File Manager to your configuration to enable workfile "
-            "management for %s." % (self._get_user_friendly_context(work_area))
+            "management here."
         )
 
 
-class UnusedContextError(WorkAreaError):
+class UnusedContextError(WorkfilesError):
     """
     Raised when a context is unused.
 
@@ -59,37 +46,32 @@ class UnusedContextError(WorkAreaError):
     are generally non leaf nodes in the tree view.
     """
 
-    def __init__(self, work_area):
+    def __init__(self):
         """
         Constructor.
 
         :param work_area: Work area that raised an error.
         """
-        WorkAreaError.__init__(
-            self, "No templates have been defined for %s." %
-            self._get_user_friendly_context(work_area)
-        )
+        WorkfilesError.__init__(self, "No templates have been defined.")
 
 
-class UnconfiguredTemplatesError(WorkAreaError):
+class UnconfiguredTemplatesError(WorkfilesError):
     """
     Raised when one or more templates are not configured.
     """
 
-    def __init__(self, missing_templates, work_area):
+    def __init__(self, missing_templates):
         """
         Constructor.
 
         :param missing_templates: List of templates that are missing.
-        :param work_area: Work area that raised an error.
         """
         if len(missing_templates) == 4:
             self._are_all_templates_empty = True
-            WorkAreaError.__init__(
+            WorkfilesError.__init__(
                 self,
-                "No templates have been defined for %s. Define the templates "
-                "in your configuration to enable workfile management here." %
-                self._get_user_friendly_context(work_area)
+                "No templates have been defined. Define the templates "
+                "in your configuration to enable workfile management here."
             )
         else:
             self._are_all_templates_empty = False
@@ -107,14 +89,13 @@ class UnconfiguredTemplatesError(WorkAreaError):
 
             is_plural = len(missing_templates) > 1
 
-            WorkAreaError.__init__(
+            WorkfilesError.__init__(
                 self,
-                "The template%s %s %s not been defined for %s.\n\n"
+                "The template%s %s %s not been defined.\n\n"
                 "Please update your pipeline configuration." % (
                     "s" if is_plural else "",
                     missing_templates_string,
-                    "have" if is_plural else "has",
-                    self._get_user_friendly_context(work_area)
+                    "have" if is_plural else "has"
                 )
             )
 

--- a/python/tk_multi_workfiles/errors.py
+++ b/python/tk_multi_workfiles/errors.py
@@ -32,27 +32,8 @@ class WorkAreaSettingsNotFoundError(WorkfilesError):
         """
         WorkfilesError.__init__(
             self,
-            "Add the Shotgun File Manager to your configuration to enable workfile "
-            "management here."
+            "The Shotgun File Manager hasn't been setup."
         )
-
-
-class UnusedContextError(WorkfilesError):
-    """
-    Raised when a context is unused.
-
-    An context is considered as unused when it it is a launch point for the file
-    manager and not a context in which we actually load or save files from. Those
-    are generally non leaf nodes in the tree view.
-    """
-
-    def __init__(self):
-        """
-        Constructor.
-
-        :param work_area: Work area that raised an error.
-        """
-        WorkfilesError.__init__(self, "No templates have been defined.")
 
 
 class UnconfiguredTemplatesError(WorkfilesError):
@@ -67,14 +48,8 @@ class UnconfiguredTemplatesError(WorkfilesError):
         :param missing_templates: List of templates that are missing.
         """
         if len(missing_templates) == 4:
-            self._are_all_templates_empty = True
-            WorkfilesError.__init__(
-                self,
-                "No templates have been defined. Define the templates "
-                "in your configuration to enable workfile management here."
-            )
+            WorkfilesError.__init__(self, "No templates have been defined.")
         else:
-            self._are_all_templates_empty = False
             # Then take every template except the last one and join them with commas.
             comma_separated_templates = missing_templates[:-1]
             comma_separated_string = ", ".join(comma_separated_templates)
@@ -91,18 +66,9 @@ class UnconfiguredTemplatesError(WorkfilesError):
 
             WorkfilesError.__init__(
                 self,
-                "The template%s %s %s not been defined.\n\n"
-                "Please update your pipeline configuration." % (
+                "The template%s %s %s not been defined." % (
                     "s" if is_plural else "",
                     missing_templates_string,
                     "have" if is_plural else "has"
                 )
             )
-
-    def are_all_templates_empty(self):
-        """
-        Indicates if only some templates are missing.
-
-        :returns: True if all templates are empty, False otherwise.
-        """
-        return self._are_all_templates_empty

--- a/python/tk_multi_workfiles/errors.py
+++ b/python/tk_multi_workfiles/errors.py
@@ -21,24 +21,9 @@ class WorkfilesError(TankError):
     """
 
 
-class WorkAreaSettingsNotFoundError(WorkfilesError):
+class MissingTemplatesError(WorkfilesError):
     """
-    Raised when no settings for the workfiles 2 app are found in an environment.
-    """
-
-    def __init__(self):
-        """
-        Constructor.
-        """
-        WorkfilesError.__init__(
-            self,
-            "The Shotgun File Manager hasn't been setup."
-        )
-
-
-class UnconfiguredTemplatesError(WorkfilesError):
-    """
-    Raised when one or more templates are not configured.
+    Raised when one or more templates are missing.
     """
 
     def __init__(self, missing_templates):
@@ -47,8 +32,15 @@ class UnconfiguredTemplatesError(WorkfilesError):
 
         :param missing_templates: List of templates that are missing.
         """
+        WorkfilesError.__init__(self, self.generate_missing_templates_message(missing_templates))
+
+    @classmethod
+    def generate_missing_templates_message(self, missing_templates):
+        """
+        Generates a warning for when templates are not all configured.
+        """
         if len(missing_templates) == 4:
-            WorkfilesError.__init__(self, "No templates have been defined.")
+            return "No templates have been defined."
         else:
             # Then take every template except the last one and join them with commas.
             comma_separated_templates = missing_templates[:-1]
@@ -64,11 +56,8 @@ class UnconfiguredTemplatesError(WorkfilesError):
 
             is_plural = len(missing_templates) > 1
 
-            WorkfilesError.__init__(
-                self,
-                "The template%s %s %s not been defined." % (
-                    "s" if is_plural else "",
-                    missing_templates_string,
-                    "have" if is_plural else "has"
-                )
+            return "The template%s %s %s not been defined." % (
+                "s" if is_plural else "",
+                missing_templates_string,
+                "have" if is_plural else "has"
             )

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -20,7 +20,6 @@ from sgtk import TankError
 
 from .file_item import FileItem
 from .user_cache import g_user_cache
-from .errors import UnconfiguredTemplatesError
 
 from .sg_published_files_model import SgPublishedFilesModel
 
@@ -879,7 +878,6 @@ class AsyncFileFinder(FileFinder):
             # build the work area for this context: This may throw, but the background task manager framework
             # will catch
             work_area = WorkArea(context)
-            work_area.assert_templates_configured()
 
         return {"environment": work_area}
 

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -887,7 +887,7 @@ class AsyncFileFinder(FileFinder):
                 work_area.assert_templates_configured()
             except UnconfiguredTemplatesError as e:
                 if e.are_all_templates_empty() and not is_leaf:
-                    raise UnusedContextError(work_area)
+                    raise UnusedContextError()
                 else:
                     raise
 

--- a/python/tk_multi_workfiles/file_list/file_group_widget.py
+++ b/python/tk_multi_workfiles/file_list/file_group_widget.py
@@ -83,6 +83,8 @@ class FileGroupWidget(GroupWidgetBase):
         # update if the spinner should be visible or not:
         if search_status == None:
             search_status = FileModel.SEARCH_COMPLETED
+
+            func
             
         # show the spinner if needed:
         self._ui.spinner.setVisible(search_status == FileModel.SEARCHING)

--- a/python/tk_multi_workfiles/file_list/file_group_widget.py
+++ b/python/tk_multi_workfiles/file_list/file_group_widget.py
@@ -84,8 +84,6 @@ class FileGroupWidget(GroupWidgetBase):
         if search_status == None:
             search_status = FileModel.SEARCH_COMPLETED
 
-            func
-            
         # show the spinner if needed:
         self._ui.spinner.setVisible(search_status == FileModel.SEARCHING)
 

--- a/python/tk_multi_workfiles/file_list/file_group_widget.py
+++ b/python/tk_multi_workfiles/file_list/file_group_widget.py
@@ -96,7 +96,7 @@ class FileGroupWidget(GroupWidgetBase):
         elif search_status == FileModel.SEARCH_COMPLETED and not idx_has_children:
             templates = work_area.get_missing_templates()
             if not work_area.are_settings_loaded():
-                search_msg = "The Shotgun File Manager hasn't been setup."
+                search_msg = "Shotgun Workfiles hasn't been setup."
             elif templates:
                 search_msg = MissingTemplatesError.generate_missing_templates_message(templates)
             else:

--- a/python/tk_multi_workfiles/file_list/file_group_widget.py
+++ b/python/tk_multi_workfiles/file_list/file_group_widget.py
@@ -19,6 +19,7 @@ from ..ui.file_group_widget import Ui_FileGroupWidget
 from ..util import get_model_data, get_model_str
 from ..framework_qtwidgets import SpinnerWidget, GroupWidgetBase
 from ..user_cache import g_user_cache
+from ..errors import MissingTemplatesError
 
 class FileGroupWidget(GroupWidgetBase):
     """
@@ -93,7 +94,13 @@ class FileGroupWidget(GroupWidgetBase):
         if search_status == FileModel.SEARCHING and not idx_has_children:
             search_msg = "Searching for files..."
         elif search_status == FileModel.SEARCH_COMPLETED and not idx_has_children:
-            search_msg = "No files found."
+            templates = work_area.get_missing_templates()
+            if not work_area.are_settings_loaded():
+                search_msg = "The Shotgun File Manager hasn't been setup."
+            elif templates:
+                search_msg = MissingTemplatesError.generate_missing_templates_message(templates)
+            else:
+                search_msg = "No files found."
         elif search_status == FileModel.SEARCH_FAILED:
             search_msg = get_model_str(model_idx, FileModel.SEARCH_MSG_ROLE)
         self._ui.msg_label.setText(search_msg)
@@ -102,6 +109,8 @@ class FileGroupWidget(GroupWidgetBase):
 
         show_msg = self._show_msg and self._ui.expand_check_box.checkState() == QtCore.Qt.Checked
         self._ui.msg_label.setVisible(show_msg)
+
+
 
     def set_expanded(self, expand=True):
         """

--- a/python/tk_multi_workfiles/file_list/file_group_widget.py
+++ b/python/tk_multi_workfiles/file_list/file_group_widget.py
@@ -93,7 +93,7 @@ class FileGroupWidget(GroupWidgetBase):
         if search_status == FileModel.SEARCHING and not idx_has_children:
             search_msg = "Searching for files..."
         elif search_status == FileModel.SEARCH_COMPLETED and not idx_has_children:
-            search_msg = "No files found!"
+            search_msg = "No files found."
         elif search_status == FileModel.SEARCH_FAILED:
             search_msg = get_model_str(model_idx, FileModel.SEARCH_MSG_ROLE)
         self._ui.msg_label.setText(search_msg)

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -590,7 +590,7 @@ class FileModel(QtGui.QStandardItemModel):
                 self._search_cache.set_dirty(search.entity, user)
 
             # actually start the search:
-            search_id = self._finder.begin_search(search.entity, self._current_users)
+            search_id = self._finder.begin_search(search.entity, search.is_leaf, self._current_users)
             self._in_progress_searches[search_id] = search
             self._app.log_debug("File Model: Started search %d..." % search_id)
 

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -590,7 +590,7 @@ class FileModel(QtGui.QStandardItemModel):
                 self._search_cache.set_dirty(search.entity, user)
 
             # actually start the search:
-            search_id = self._finder.begin_search(search.entity, search.is_leaf, self._current_users)
+            search_id = self._finder.begin_search(search.entity, self._current_users)
             self._in_progress_searches[search_id] = search
             self._app.log_debug("File Model: Started search %d..." % search_id)
 

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -28,6 +28,7 @@ from .work_area import WorkArea
 from .file_item import FileItem
 from .file_finder import FileFinder
 from .util import value_to_str
+from .errors import MissingTemplatesError
 
 from .actions.save_as_file_action import SaveAsFileAction
 
@@ -323,7 +324,10 @@ class FileSaveForm(FileFormBase):
         # first make  sure the environment is complete:
         if not env or not env.context:
             raise TankError("Please select a work area to save into.")
-        env.assert_templates_configured()
+
+        templates = env.get_missing_templates()
+        if templates:
+            raise MissingTemplatesError(templates)
 
         # build the fields dictionary from the environment:
         fields = {}

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -276,7 +276,7 @@ class WorkArea(object):
         if not missing_templates:
             return
         else:
-            raise UnconfiguredTemplatesError(missing_templates, self)
+            raise UnconfiguredTemplatesError(missing_templates)
 
     def _get_settings_for_context(self, context, templates_to_find, settings_to_find=None):
         """
@@ -313,7 +313,7 @@ class WorkArea(object):
             # need to look for settings in a different context/environment
             settings = self._get_raw_app_settings_for_context(app, context)
             if not settings:
-                raise WorkAreaSettingsNotFoundError(self)
+                raise WorkAreaSettingsNotFoundError()
 
             # get templates:
             resolved_settings = {}

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -258,8 +258,6 @@ class WorkArea(object):
         """
         Asserts that all the templates are configured.
 
-        :param is_leaf: Indicates if this work area in a leaf in the tree view.
-
         :raises UnconfiguredTemplatesError: Raised if one or more template is not configured.
         """
         # First find all the templates that are not defined.

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -24,7 +24,7 @@ from .errors import UnconfiguredTemplatesError, WorkAreaSettingsNotFoundError
 class WorkArea(object):
     """
     Class containing information about the current work area including context, templates
-    and other miscelaneous work-area specific settings.
+    and other miscellaneous work-area specific settings.
     """
 
     class _SettingsCache(Threaded):
@@ -257,6 +257,8 @@ class WorkArea(object):
     def assert_templates_configured(self):
         """
         Asserts that all the templates are configured.
+
+        :param is_leaf: Indicates if this work area in a leaf in the tree view.
 
         :raises UnconfiguredTemplatesError: Raised if one or more template is not configured.
         """

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -26,6 +26,9 @@ class WorkArea(object):
     and other miscellaneous work-area specific settings.
     """
 
+    # Number of template settings for the app.
+    NB_TEMPLATE_SETTINGS = 4
+
     class _SettingsCache(Threaded):
         """
         Cache of settings per context.


### PR DESCRIPTION
While the last update to error reporting was a lot better than what we had before, we went from no error messages to way to way too alarmous error messages. This branch tries to find some middle ground by being informative and not have people think is something is actually broken and need to be taken care of. 

The approach taken was to first make the messages more neutral. Second, most of these "errors" are actually entirely valid states for the application, in certain contexts. Therefore, the way these warnings are flowing through the code are different, so that they don't get reported as errors by the backend and end up showing in error logs, especially in Maya where the message area turned red even for innocuous messages.

Therefore, all "errors" related to missing templates or missing app in the environment are treated as warnings and take a new code path. Internal errors and YAML parsing errors however are still regarded as actual error and will be reported like before, as they should be.


![screen shot 2016-05-13 at 1 35 32 pm](https://cloud.githubusercontent.com/assets/8126447/15256646/766d3e54-1910-11e6-9cb9-b69990f2fcfc.png)
![screen shot 2016-05-13 at 12 29 54 pm](https://cloud.githubusercontent.com/assets/8126447/15256648/7673a6c2-1910-11e6-8f06-c8adfc9048c8.png)