### PR TITLE
For #36753, workfiles unexpected switching

### DIFF
--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -160,7 +160,7 @@ class BrowserForm(QtGui.QWidget):
         if my_tasks_model:
             # create my tasks form:
             self._my_tasks_form = MyTasksForm(my_tasks_model, allow_task_creation, parent=self)
-            self._my_tasks_form.entity_selected.connect(self._on_my_task_selected)
+            self._my_tasks_form.entity_selected.connect(self._on_entity_selected)
             self._ui.task_browser_tabs.addTab(self._my_tasks_form, "My Tasks")
             self._my_tasks_form.create_new_task.connect(self.create_new_task)
 
@@ -335,50 +335,6 @@ class BrowserForm(QtGui.QWidget):
         """
         local_pnt = self.sender().mapTo(self, pnt)
         self.file_context_menu_requested.emit(file, env, local_pnt)
-
-    def _on_my_task_selected(self, task, breadcrumb_trail):
-        """
-        Called when user picks a new task in the My Tasks tab.
-
-        :param task: Selected task.
-        :param breadcrumb_trail: List of breadcrumbs.
-        """
-        # ignore if the sender isn't the current tab:
-        if self._ui.task_browser_tabs.currentWidget() != self.sender():
-            return
-
-        selected_entity = self._on_selected_task_changed(task, breadcrumb_trail)
-        if task:
-            self._update_selected_entity(selected_entity["type"], selected_entity["id"])
-        else:
-            self._update_selected_entity(None, None)
-
-    def _on_selected_task_changed(self, selection_details, breadcrumb_trail):
-        """
-        """
-        search_details = []
-        task = None
-        if selection_details:
-            task = selection_details["entity"]
-
-            search_label = task.get("content")
-            step = task.get("step")
-            if step:
-                search_label = "%s - %s" % (step.get("name"), search_label)
-
-            details = FileModel.SearchDetails(search_label)
-            details.entity = task
-            details.is_leaf = True
-            search_details.append(details)
-
-        # refresh files:
-        if self._file_model:
-            self._file_model.set_entity_searches(search_details)
-
-        # emit work-area-changed signal:
-        self._emit_work_area_changed(task, breadcrumb_trail)
-
-        return task
 
     def _on_entity_selected(self, selection_details, breadcrumb_trail):
         """

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -104,12 +104,12 @@ class EntityTreeForm(QtGui.QWidget):
         entity_model.modelReset.connect(self._model_reset)
 
         if entity_model:
+            entity_model.data_refreshed.connect(self._on_data_refreshed)
 
             if True:
                 # create a filter proxy model between the source model and the task tree view:
                 filter_model = EntityTreeProxyModel(self, ["content", {"entity": "name"}] + extra_filter_fields)
                 monitor_qobject_lifetime(filter_model, "%s entity filter model" % search_label)
-                filter_model.rowsInserted.connect(self._on_filter_model_rows_inserted)
                 filter_model.setSourceModel(entity_model)
                 self._ui.entity_tree.setModel(filter_model)
 
@@ -511,7 +511,7 @@ class EntityTreeForm(QtGui.QWidget):
         # emit selection_changed signal:
         self.entity_selected.emit(selection_details, breadcrumbs)
 
-    def _on_filter_model_rows_inserted(self, parent_idx, first, last):
+    def _on_data_refreshed(self, modifications_made):
         """
         Slot triggered when new rows are inserted into the filter model.  When this happens
         we just make sure that any new root rows are expanded.
@@ -520,6 +520,9 @@ class EntityTreeForm(QtGui.QWidget):
         :param first:       The first row id inserted
         :param last:        The last row id inserted
         """
+        if not modifications_made:
+            return
+
         # expand any new root rows:
         self._expand_root_rows()
 

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -51,7 +51,7 @@ class EntityTreeForm(QtGui.QWidget):
     # Signal emitted when the 'New Task' button is clicked.
     create_new_task = QtCore.Signal(object, object)# entity, step
 
-    def __init__(self, entity_model, search_label, allow_task_creation, extra_filter_fields, parent):
+    def __init__(self, entity_model, search_label, allow_task_creation, extra_fields, parent):
         """
         Construction
 
@@ -59,6 +59,7 @@ class EntityTreeForm(QtGui.QWidget):
         :param search_label:        The hint label to be displayed on the search control
         :param allow_task_creation: Indicates if the form is allowed by the app settings to show the
                                     create task button.
+        :param extra_fields:        Extra fields to use when comparing model entries.
         :param parent:              The parent QWidget for this control
         """
         QtGui.QWidget.__init__(self, parent)
@@ -104,11 +105,13 @@ class EntityTreeForm(QtGui.QWidget):
         entity_model.modelReset.connect(self._model_reset)
 
         if entity_model:
+            # Every time the model is refreshed with data from Shotgun, we'll need to re-expand nodes
+            # that were expanded and reapply the current selection.
             entity_model.data_refreshed.connect(self._on_data_refreshed)
 
             if True:
                 # create a filter proxy model between the source model and the task tree view:
-                filter_model = EntityTreeProxyModel(self, ["content", {"entity": "name"}] + extra_filter_fields)
+                filter_model = EntityTreeProxyModel(self, ["content", {"entity": "name"}] + extra_fields)
                 monitor_qobject_lifetime(filter_model, "%s entity filter model" % search_label)
                 filter_model.setSourceModel(entity_model)
                 self._ui.entity_tree.setModel(filter_model)

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -1,39 +1,46 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Implementation of the entity tree widget consisting of a tree view that displays the 
+Implementation of the entity tree widget consisting of a tree view that displays the
 contents of a Shotgun Data Model, a text search and a filter control.
 """
 import weakref
 
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
+from ..ui.entity_tree_form import Ui_EntityTreeForm
+from .entity_tree_proxy_model import EntityTreeProxyModel
+from ..framework_qtwidgets import Breadcrumb
+from ..util import get_model_str, map_to_source, get_source_model, monitor_qobject_lifetime
 
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 ShotgunEntityModel = shotgun_model.ShotgunEntityModel
 
-from ..ui.entity_tree_form import Ui_EntityTreeForm
-from .entity_tree_proxy_model import EntityTreeProxyModel
-from ..framework_qtwidgets import Breadcrumb
-from ..util import get_model_data, get_model_str, map_to_source, get_source_model, monitor_qobject_lifetime
 
 class EntityTreeForm(QtGui.QWidget):
     """
     Entity tree widget class
     """
+
     class _EntityBreadcrumb(Breadcrumb):
         """
+        Breadcrumb for a single model item.
         """
+
         def __init__(self, label, entity):
             """
+            Constructor.
+
+            :param label: Text label for the breabcrumb.
+            :param entity: Entity associated with this breadcrumb.
             """
             Breadcrumb.__init__(self, label)
             self.entity = entity
@@ -55,7 +62,7 @@ class EntityTreeForm(QtGui.QWidget):
         :param parent:              The parent QWidget for this control
         """
         QtGui.QWidget.__init__(self, parent)
-        
+
         # control if step->tasks in the entity hierarchy should be collapsed when building
         # the search details.
         self._collapse_steps_with_tasks = True
@@ -63,13 +70,13 @@ class EntityTreeForm(QtGui.QWidget):
         self._entity_to_select = None
         # keep track of the currently selected item:
         self._current_item_ref = None
-        
+
         # keep track of expanded items as items in the tree are expanded/collapsed.  We
         # also want to auto-expand root items the first time they appear so track them
         # as well
         self._expanded_items = set()
         self._auto_expanded_root_items = set()
-        
+
         # set up the UI
         self._ui = Ui_EntityTreeForm()
         self._ui.setupUi(self)
@@ -96,13 +103,13 @@ class EntityTreeForm(QtGui.QWidget):
 
             if True:
                 # create a filter proxy model between the source model and the task tree view:
-                filter_model = EntityTreeProxyModel(self, ["content", {"entity":"name"}] + extra_filter_fields)
+                filter_model = EntityTreeProxyModel(self, ["content", {"entity": "name"}] + extra_filter_fields)
                 monitor_qobject_lifetime(filter_model, "%s entity filter model" % search_label)
                 filter_model.rowsInserted.connect(self._on_filter_model_rows_inserted)
                 filter_model.setSourceModel(entity_model)
                 self._ui.entity_tree.setModel(filter_model)
-    
-                # connect up the filter controls: 
+
+                # connect up the filter controls:
                 self._ui.search_ctrl.search_edited.connect(self._on_search_changed)
                 self._ui.my_tasks_cb.toggled.connect(self._on_my_tasks_only_toggled)
             else:
@@ -164,7 +171,7 @@ class EntityTreeForm(QtGui.QWidget):
 
     def get_selection(self):
         """
-        Get the currently selected item as well as the breadcrumb trail that represents 
+        Get the currently selected item as well as the breadcrumb trail that represents
         the path for the selection.
 
         :returns:   A Tuple containing the details and breadcrumb trail of the current selection:
@@ -270,17 +277,17 @@ class EntityTreeForm(QtGui.QWidget):
     def _get_entity_details(self, idx):
         """
         Get entity details for the specified model index.  If steps are being collapsed into tasks
-        then these details will reflect that and will not be a 1-1 representation of the tree itself. 
+        then these details will reflect that and will not be a 1-1 representation of the tree itself.
 
-        :param idx: The QModelIndex of the item to get the entity details for. 
-        :returns:   A dictionary containing entity information about the specified index containing the 
+        :param idx: The QModelIndex of the item to get the entity details for.
+        :returns:   A dictionary containing entity information about the specified index containing the
                     following information:
-                    
+
                         {"label":label, "entity":entity, "children":[children]}
 
                     - label:      The label of the corresponding item
                     - entity:     The entity dictionary for the corresponding item
-                    - children:   A list of immediate children for the corresponding item - each item in 
+                    - children:   A list of immediate children for the corresponding item - each item in
                                   the list is a dictionary containing 'label' and 'entity'.
         """
         if not idx.isValid():
@@ -298,18 +305,18 @@ class EntityTreeForm(QtGui.QWidget):
         # get details for children:
         children = []
         collapsed_children = []
-        
-        view_model = self._ui.entity_tree.model() 
+
+        view_model = self._ui.entity_tree.model()
         for row in range(view_model.rowCount(idx)):
             child_idx = view_model.index(row, 0, idx)
             child_item = self._item_from_index(child_idx)
             if not child_item:
                 continue
-            
+
             child_label = get_model_str(child_item)
             child_entity = entity_model.get_entity(child_item)
             children.append({"label":child_label, "entity":child_entity})
-            
+
             if self._collapse_steps_with_tasks and child_entity and child_entity["type"] == "Step":
                 # see if grand-child is actually a task:
                 for child_row in range(view_model.rowCount(child_idx)):
@@ -317,7 +324,7 @@ class EntityTreeForm(QtGui.QWidget):
                     grandchild_item = self._item_from_index(grandchild_idx)
                     if not grandchild_item:
                         continue
-                    
+
                     grandchild_label = get_model_str(grandchild_item)
                     grandchild_entity = entity_model.get_entity(grandchild_item)
                     if grandchild_entity and grandchild_entity["type"] == "Task":
@@ -338,11 +345,11 @@ class EntityTreeForm(QtGui.QWidget):
                 if child_entity and child_entity["type"] == "Task":
                     collapsed_child_label = "%s - %s" % (label, child_label)
                     collapsed_children.append({"label":collapsed_child_label, "entity":child_entity})
-                    
+
             if collapsed_children:
                 entity = None
                 children = collapsed_children
-        
+
         return {"label":label, "entity":entity, "children":children}
 
     def _on_search_changed(self, search_text):
@@ -366,7 +373,7 @@ class EntityTreeForm(QtGui.QWidget):
         """
         Slot triggered when the show-my-tasks checkbox is toggled
 
-        :param checked: True if the checkbox has been checked, otherwise False 
+        :param checked: True if the checkbox has been checked, otherwise False
         """
         # reset the current selection without emitting any signals:
         prev_selected_item = self._reset_selection()
@@ -379,16 +386,16 @@ class EntityTreeForm(QtGui.QWidget):
 
     def _update_selection(self, prev_selected_item):
         """
-        Update the selection to either the to-be-selected entity if set or the current item if known.  The 
-        current item is the item that was last selected but which may no longer be visible in the view due 
-        to filtering.  This allows it to be tracked so that the selection state is correctly restored when 
+        Update the selection to either the to-be-selected entity if set or the current item if known.  The
+        current item is the item that was last selected but which may no longer be visible in the view due
+        to filtering.  This allows it to be tracked so that the selection state is correctly restored when
         it becomes visible again.
         """
         entity_model = get_source_model(self._ui.entity_tree.model())
         if not entity_model:
             return
 
-        # we want to make sure we don't emit any signals whilst we are 
+        # we want to make sure we don't emit any signals whilst we are
         # manipulating the selection:
         signals_blocked = self.blockSignals(True)
         try:
@@ -426,7 +433,7 @@ class EntityTreeForm(QtGui.QWidget):
                 selection_details, breadcrumbs = self.get_selection()
 
                 # emit a selection changed signal:
-                self._emit_entity_selected(selection_details, breadcrumbs)
+                self.entity_selected.emit(selection_details, breadcrumbs)
 
     def _update_ui(self):
         """
@@ -440,7 +447,6 @@ class EntityTreeForm(QtGui.QWidget):
             entity_model = get_source_model(selected_indexes[0].model())
             if item and entity_model:
                 entity = entity_model.get_entity(item)
-                #if entity and entity.get("type") in ("Step", "Task"):
                 if entity and entity["type"] != "Step":
                     if entity["type"] == "Task":
                         if entity.get("entity"):
@@ -479,7 +485,7 @@ class EntityTreeForm(QtGui.QWidget):
             self._entity_to_select = None
 
         # emit selection_changed signal:
-        self._emit_entity_selected(selection_details, breadcrumbs)
+        self.entity_selected.emit(selection_details, breadcrumbs)
 
     def _on_filter_model_rows_inserted(self, parent_idx, first, last):
         """
@@ -641,6 +647,11 @@ class EntityTreeForm(QtGui.QWidget):
 
     def _build_breadcrumb_trail(self, idx):
         """
+        Builds the breadcrumb trail for the selected model index.
+
+        :param idx: Index of an item in the selection model.
+
+        :returns: List of _EntityBreadcrumb for each item in the hierarchy.
         """
         if not idx.isValid():
             return []
@@ -663,9 +674,3 @@ class EntityTreeForm(QtGui.QWidget):
 
         # return reversed list:
         return breadcrumbs[::-1]
-
-    def _emit_entity_selected(self, entity_details, breadcrumbs):
-        """
-        """
-        self.entity_selected.emit(entity_details, breadcrumbs)
-

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -44,13 +44,15 @@ class EntityTreeForm(QtGui.QWidget):
     # Signal emitted when the 'New Task' button is clicked.
     create_new_task = QtCore.Signal(object, object)# entity, step
 
-    def __init__(self, entity_model, search_label, allow_task_creation, parent):
+    def __init__(self, entity_model, search_label, allow_task_creation, extra_filter_fields, parent):
         """
         Construction
 
-        :param entity_model:    The Shotgun Model this widget should connect to
-        :param search_label:    The hint label to be displayed on the search control
-        :param parent:          The parent QWidget for this control
+        :param entity_model:        The Shotgun Model this widget should connect to
+        :param search_label:        The hint label to be displayed on the search control
+        :param allow_task_creation: Indicates if the form is allowed by the app settings to show the
+                                    create task button.
+        :param parent:              The parent QWidget for this control
         """
         QtGui.QWidget.__init__(self, parent)
         
@@ -94,7 +96,7 @@ class EntityTreeForm(QtGui.QWidget):
 
             if True:
                 # create a filter proxy model between the source model and the task tree view:
-                filter_model = EntityTreeProxyModel(self, ["content", {"entity":"name"}])
+                filter_model = EntityTreeProxyModel(self, ["content", {"entity":"name"}] + extra_filter_fields)
                 monitor_qobject_lifetime(filter_model, "%s entity filter model" % search_label)
                 filter_model.rowsInserted.connect(self._on_filter_model_rows_inserted)
                 filter_model.setSourceModel(entity_model)

--- a/python/tk_multi_workfiles/my_tasks/my_task_item_delegate.py
+++ b/python/tk_multi_workfiles/my_tasks/my_task_item_delegate.py
@@ -29,6 +29,7 @@ class MyTaskItemDelegate(WidgetDelegate):
         """
         WidgetDelegate.__init__(self, view)
         self._extra_display_fields = extra_display_fields
+        view.setRootIsDecorated(False)
 
         self._paint_widget = None
         self._widget_sz = None

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -39,7 +39,7 @@ class MyTasksForm(EntityTreeForm):
 
         # Sets an item delete to show a list of tiles for tasks instead of nodes in a tree.
         self._item_delegate = None
-        if tasks_model and True:
+        if True:
             # create the item delegate - make sure we keep a reference to the delegate otherwise
             # things may crash later on!
             self._item_delegate = MyTaskItemDelegate(tasks_model.extra_display_fields, self._ui.entity_tree)

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -1,45 +1,27 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Implementation of the my tasks list widget consisting of a list view displaying the contents
 of a Shotgun data model of my tasks, a text search and a filter control.
 """
-import weakref
-
-import sgtk
-from sgtk.platform.qt import QtCore, QtGui
 
 from .my_task_item_delegate import MyTaskItemDelegate
-from ..entity_proxy_model import EntityProxyModel
-from ..ui.my_tasks_form import Ui_MyTasksForm
-from ..framework_qtwidgets import Breadcrumb
-from ..util import map_to_source, get_source_model, monitor_qobject_lifetime
+from ..util import monitor_qobject_lifetime
+from ..entity_tree.entity_tree_form import EntityTreeForm
 
-class MyTasksForm(QtGui.QWidget):
+
+class MyTasksForm(EntityTreeForm):
     """
     My Tasks widget class
     """
-
-    class _TaskBreadcrumb(Breadcrumb):
-        """
-        """
-        def __init__(self, label, task_id):
-            Breadcrumb.__init__(self, label)
-            self.task_id = task_id
-
-    # Signal emitted when a task is selected in the tree
-    task_selected = QtCore.Signal(object, list)# task, breadcrumb trail
-
-    # Signal emitted when the 'New Task' button is clicked
-    create_new_task = QtCore.Signal(object, object)# entity, step
 
     def __init__(self, tasks_model, allow_task_creation, parent):
         """
@@ -48,56 +30,17 @@ class MyTasksForm(QtGui.QWidget):
         :param model:   The Shotgun Model this widget should connect to
         :param parent:  The parent QWidget for this control
         """
-        QtGui.QWidget.__init__(self, parent)
+        EntityTreeForm.__init__(self, tasks_model, "My Tasks", allow_task_creation, tasks_model.extra_display_fields, parent)
 
-        # keep track of the task to select when/if it appears in the model
-        self._task_id_to_select = None
-        # keep track of the currently selected item
-        self._current_item_ref = None
-
-        # set up the UI
-        self._ui = Ui_MyTasksForm()
-        self._ui.setupUi(self)
-
-        # tmp until we have a usable filter button!
-        self._ui.filter_btn.hide()
-
-        self._ui.search_ctrl.set_placeholder_text("Search My Tasks")
-
-        # enable/hide the new task button depending if task creation is allowed:
-        if allow_task_creation:
-            self._ui.new_task_btn.clicked.connect(self._on_new_task)
-            self._ui.new_task_btn.setEnabled(False)
-        else:
-            self._ui.new_task_btn.hide()
+        self._ui.my_tasks_cb.hide()
 
         self._item_delegate = None
-        if tasks_model:
-
-            if True:
-                # create a filter proxy model between the source model and the task tree view:
-                filter_fields = ["content", {"entity":"name"}]
-                filter_fields.extend(tasks_model.extra_display_fields)
-                filter_model = EntityProxyModel(self, filter_fields)
-                monitor_qobject_lifetime(filter_model, "My Tasks filter model")
-                filter_model.rowsInserted.connect(self._on_filter_model_rows_inserted)
-                filter_model.setSourceModel(tasks_model)
-                self._ui.task_tree.setModel(filter_model)
-
-                # create the item delegate - make sure we keep a reference to the delegate otherwise 
-                # things may crash later on!
-                self._item_delegate = MyTaskItemDelegate(tasks_model.extra_display_fields, self._ui.task_tree)
-                monitor_qobject_lifetime(self._item_delegate)
-                self._ui.task_tree.setItemDelegate(self._item_delegate)
-
-                self._ui.search_ctrl.search_edited.connect(self._on_search_changed)
-            else:
-                self._ui.task_tree.setModel(tasks_model)
-
-        # connect to the selection model for the tree view:
-        selection_model = self._ui.task_tree.selectionModel()
-        if selection_model:
-            selection_model.selectionChanged.connect(self._on_selection_changed)
+        if tasks_model and True:
+            # create the item delegate - make sure we keep a reference to the delegate otherwise
+            # things may crash later on!
+            self._item_delegate = MyTaskItemDelegate(tasks_model.extra_display_fields, self._ui.entity_tree)
+            monitor_qobject_lifetime(self._item_delegate)
+            self._ui.entity_tree.setItemDelegate(self._item_delegate)
 
     def shut_down(self):
         """
@@ -105,291 +48,12 @@ class MyTasksForm(QtGui.QWidget):
         """
         signals_blocked = self.blockSignals(True)
         try:
-            # clear any references:
-            self._current_item_ref = None
-
-            # clear the selection:
-            if self._ui.task_tree.selectionModel():
-                self._ui.task_tree.selectionModel().clear()
-
-            # detach the filter model from the view:
-            view_model = self._ui.task_tree.model()
-            if view_model:
-                self._ui.task_tree.setModel(None)
-                if isinstance(view_model, EntityProxyModel):
-                    view_model.setSourceModel(None)
-
+            EntityTreeForm.shut_down(self)
             # detach and clean up the item delegate:
-            self._ui.task_tree.setItemDelegate(None)
+            self._ui.entity_tree.setItemDelegate(None)
             if self._item_delegate:
                 self._item_delegate.setParent(None)
                 self._item_delegate.deleteLater()
                 self._item_delegate = None
-
         finally:
             self.blockSignals(signals_blocked)
-
-    def select_task(self, task_id):
-        """
-        Select the specified task in the list.  If the list is still being populated then the
-        selection will happen when an item representing the entity appears in the model.
-
-        Note that this doesn't emit a task_selected signal
-
-        :param task_id: The id of the Shotgun Task to select
-        :returns:       True if an item is selected, otherwise False
-        """
-        # track the selected task - this allows the task to be selected when
-        # it appears in the model if the model hasn't been fully populated yet:
-        self._task_id_to_select = task_id
-
-        # reset the current selection without emitting a signal:
-        prev_selected_item = self._reset_selection()
-        self._current_item_ref = None
-
-        # try to update the selection:
-        self._update_selection(prev_selected_item)
-
-    def get_selection(self):
-        """
-        Get the currently selected task as well as the breadcrumb trail that represents 
-        the path for the selection.
-
-        :returns:   A Tuple containing the task and breadcrumb trail of the current selection:
-                        (task, breadcrumb_trail)
-
-                    - task is a Shotgun entity dictionary
-                    - breadcrumb_trail is a list of Breadcrumb instances
-        """
-        item = self._get_selected_item()
-        task = item.get_sg_data() if item else None
-        breadcrumb_trail = self._build_breadcrumb_trail()
-        return (task, breadcrumb_trail)
-
-    def navigate_to(self, breadcrumb_trail):
-        """
-        Update the selection to match the specified breadcrumb trail
-
-        :param breadcrumb_trail:    A list of Breadcrumb instances that represent
-                                    an item in the task list.
-        """
-        task_id_to_select = None
-        if breadcrumb_trail and isinstance(breadcrumb_trail[-1], MyTasksForm._TaskBreadcrumb):
-            task_id_to_select = breadcrumb_trail[-1].task_id
-
-        self.select_task(task_id_to_select)
-
-    # ------------------------------------------------------------------------------------------
-    # ------------------------------------------------------------------------------------------
-
-    def _get_selected_item(self):
-        """
-        Get the currently selected item.
-
-        :returns:   The currently selected model item if any
-        """
-        item = None
-        indexes = self._ui.task_tree.selectionModel().selectedIndexes()
-        if len(indexes) == 1:
-            item = self._item_from_index(indexes[0])
-        return item
-
-    def _reset_selection(self):
-        """
-        Reset the current selection, returning the currently selected item if any.  This
-        doesn't result in any signals being emitted by the current selection model.
-
-        :returns:   The selected item before the selection was reset if any
-        """
-        prev_selected_item = self._get_selected_item()
-        # reset the current selection without emitting any signals:
-        self._ui.task_tree.selectionModel().reset()
-        self._update_ui()
-        return prev_selected_item
-
-    def _item_from_index(self, idx):
-        """
-        Find the corresponding model item from the specified index.  This handles
-        the indirection introduced by the filter model.
-
-        :param idx: The model index to find the item for
-        :returns:   The item in the model represented by the index
-        """
-        src_idx = map_to_source(idx)
-        return src_idx.model().itemFromIndex(src_idx)
-
-    def _update_selection(self, prev_selected_item=None):
-        """
-        Update the selection to either the to-be-selected task if set or the current item if known.  The 
-        current item is the item that was last selected but which may no longer be visible in the view due 
-        to filtering.  This allows it to be tracked so that the selection state is correctly restored when 
-        it becomes visible again.
-        """
-        tasks_model = get_source_model(self._ui.task_tree.model())
-        if not tasks_model:
-            return
-
-        # we want to make sure we don't emit any signals whilst we are 
-        # manipulating the selection:
-        signals_blocked = self.blockSignals(True)
-        try:
-            item = None
-            if tasks_model and self._task_id_to_select:
-                # we know about a task that we should try to select:
-                item = tasks_model.item_from_entity("Task", self._task_id_to_select)
-            elif self._current_item_ref:
-                # an item was previously selected and we are tracking it
-                item = self._current_item_ref()
-
-            if item:
-                view_model = self._ui.task_tree.model()
-                idx = item.index()
-                if isinstance(view_model, QtGui.QAbstractProxyModel):
-                    idx = view_model.mapFromSource(idx)
-                if idx.isValid():
-                    # scroll to the item in the list:
-                    self._ui.task_tree.scrollTo(idx)
-
-                    # select the item as the current item:
-                    self._ui.task_tree.selectionModel().setCurrentIndex(idx, QtGui.QItemSelectionModel.SelectCurrent)
-
-        finally:
-            self.blockSignals(signals_blocked)
-
-            # if the selection is different to the previously selected item then we
-            # will emit a task_selected signal:
-            selected_item = self._get_selected_item()
-            if id(selected_item) != id(prev_selected_item):
-                # emit a selection changed signal:
-                task = None
-                if selected_item:
-                    task = selected_item.get_sg_data()
-
-                # emit the signal
-                self._emit_task_selected(task)
-                self.repaint()
-
-    def _on_search_changed(self, search_text):
-        """
-        Slot triggered when the search text has been changed.
-
-        :param search_text: The new search text
-        """
-        # clear the selection before changing anything - reset clears the selection
-        # without emitting any signals:
-        prev_selected_item = self._reset_selection()
-        try:
-            # update the proxy filter search text:
-            self._update_filter(search_text)
-        finally:
-            # and update the selection - this will restore the original selection if possible.
-            self._update_selection(prev_selected_item)
-                
-    def _on_selection_changed(self, selected, deselected):
-        """
-        Slot triggered when the selection changes
-
-        :param selected:    QItemSelection containing any newly selected indexes
-        :param deselected:  QItemSelection containing any newly deselected indexes
-        """
-        # get the task for the current selection:
-        task = None
-        item = None
-        selected_indexes = selected.indexes()
-        if len(selected_indexes) == 1:
-            item = self._item_from_index(selected_indexes[0])
-            task = item.get_sg_data() if item else None
-
-        # update the UI:
-        self._update_ui()
-
-        # make sure we track the current task:
-        self._current_item_ref = weakref.ref(item) if item else None
-
-        if self._current_item_ref:
-            # clear the task-to-select as the current item now takes precedence
-            self._task_id_to_select = None
-
-        # emit selection_changed signal:
-        self._emit_task_selected(task)
-
-    def _on_filter_model_rows_inserted(self, parent, first, last):
-        """
-        Slot triggered when new rows are inserted into the filter model.  This allows us
-        to update the selection if a new row matches the task-to-select.
-
-        :param parent_idx:  The parent model index of the rows that were inserted
-        :param first:       The first row id inserted
-        :param last:        The last row id inserted
-        """
-        # try to select the current task from the new items in the model:
-        prev_selected_item = self._get_selected_item()
-        self._update_selection(prev_selected_item)
-
-    def _update_ui(self):
-        """
-        Update the UI to reflect the current selection, etc.
-        """
-        enable_new_tasks = False
-        if len(self._ui.task_tree.selectionModel().selectedIndexes()) == 1:
-            # something is selected so we can add a new task
-            enable_new_tasks = True
-
-        self._ui.new_task_btn.setEnabled(enable_new_tasks)
-
-    def _update_filter(self, search_text):
-        """
-        Update the search text in the filter model.
-
-        :param search_text: The new search text to update the filter model with
-        """
-        view_model = self._ui.task_tree.model()
-        if not isinstance(view_model, EntityProxyModel):
-            return
-
-        # update the proxy filter search text:
-        filter_reg_exp = QtCore.QRegExp(search_text, QtCore.Qt.CaseInsensitive, QtCore.QRegExp.FixedString)
-        view_model.setFilterRegExp(filter_reg_exp)
-
-    def _on_new_task(self):
-        """
-        Slot triggered when the new task button is clicked.  Extracts the necessary
-        information from the widget and raises a uniform signal for containing code
-        """
-        # get the currently selected task:
-        item = self._get_selected_item()
-        task = item.get_sg_data() if item else None
-        if not task:
-            return
-
-        entity = task.get("entity")
-        if not entity:
-            return
-        step = task.get("step")
-
-        self.create_new_task.emit(entity, step)
-
-    def _build_breadcrumb_trail(self):
-        """
-        """
-        breadcrumbs = []
-        item = self._get_selected_item()
-        task = item.get_sg_data() if item else None
-        if task:
-            entity = task.get("entity")
-            if entity:
-                breadcrumbs.append(Breadcrumb("<b>%s</b> %s" % (entity["type"], entity["name"])))
-            step = task.get("step")
-            if step:
-                breadcrumbs.append(Breadcrumb("<b>Step</b> %s" % step["name"]))
-
-            # finally, add task breadcrumb:
-            breadcrumbs.append(MyTasksForm._TaskBreadcrumb("<b>Task</b> %s" % task["content"], task["id"]))
-
-        return breadcrumbs
-
-    def _emit_task_selected(self, task):
-        """
-        """
-        breadcrumbs = self._build_breadcrumb_trail()
-        self.task_selected.emit(task, breadcrumbs)

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -30,10 +30,14 @@ class MyTasksForm(EntityTreeForm):
         :param model:   The Shotgun Model this widget should connect to
         :param parent:  The parent QWidget for this control
         """
-        EntityTreeForm.__init__(self, tasks_model, "My Tasks", allow_task_creation, tasks_model.extra_display_fields, parent)
+        EntityTreeForm.__init__(
+            self, tasks_model, "My Tasks", allow_task_creation, tasks_model.extra_display_fields, parent
+        )
 
+        # There is no need for the my tasks toggle.
         self._ui.my_tasks_cb.hide()
 
+        # Sets an item delete to show a list of tiles for tasks instead of nodes in a tree.
         self._item_delegate = None
         if tasks_model and True:
             # create the item delegate - make sure we keep a reference to the delegate otherwise


### PR DESCRIPTION
The main problem this branch fixes is the unexpected context switching when saving a scene. This happened every single time a model was being refreshed when in the file save dialog. To do this, I went through several iterations of code changes, each corresponding to a single commit:

- I've started by refactoring the MyTasksForm and EntityTreeForm, which shared very similar code. MyTasksForm is now a special case of EntityTreeForm and therefore deriving from it.
- I then did some PEP8 checks (but not all) on the edited files because... why not? :)
- Then I fixed the issue where the selection was being updated at the model was being torn down, which forced the entity form selection to keep updating and in the end pick the very first item in the list and effectively changed the context in which we'd save.
- Finally, I fixed a small slowdown introduced by listening to all rows being inserted. We only really need to know when the model has been refreshed to know when the selection can be updated and therefore we're only listening for that event now.

I recommend reviewing this one commit at a time.