### PR TITLE
For #36509, workfiles2 sometimes creating dir structure for wrong engine

### DIFF
--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -34,7 +34,7 @@ class FileAction(Action):
             # (AD) - does this work with non-standard hierarchies? e.g. /Task/Entity?
             ctx_entity = ctx.task or ctx.entity or ctx.project
             app.sgtk.create_filesystem_structure(ctx_entity.get("type"), ctx_entity.get("id"), 
-                                                       engine=app.engine.name)
+                                                       engine=app.engine.instance_name)
             
         finally:
             QtGui.QApplication.restoreOverrideCursor()


### PR DESCRIPTION
The Shotgun File Manager now uses the engine instance name when creating the filesystem structure in order to differentiate between 3 different configurations of the same engine, e.g. Nuke, Nuke Studio and Hiero 9.