### PR TITLE
For #36917, fix project-based publish filter

### DIFF
--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -905,8 +905,8 @@ class AsyncFileFinder(FileFinder):
         Runs in main thread.
         """
         publish_filters = []
-        if work_area.context.entity:
-            publish_filters.append(["entity", "is", work_area.context.entity])
+        # If there is no entity in the context then we are trying to load the publishes from the project.
+        publish_filters.append(["entity", "is", work_area.context.entity or work_area.context.project])
         if work_area.context.task:
             publish_filters.append(["task", "is", work_area.context.task])
         elif work_area.context.step:


### PR DESCRIPTION
When in the project context, `context.entity` is actually `None`, which meant no filtering was done at all and we were retrieving all publishes for a project.