### PR TITLE
Accounts for receiving datetime.datetime objects from SG.

### DIFF
--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -927,7 +927,9 @@ class AsyncFileFinder(FileFinder):
             # convert created_at unix time stamp to shotgun std time stamp for all publishes
             for sg_publish in sg_publishes:
                 created_at = sg_publish.get("created_at")
-                if created_at:
+                if created_at and isinstance(created_at, datetime):
+                    sg_publish["created_at"] = created_at
+                elif created_at:
                     created_at = datetime.fromtimestamp(created_at, sg_timezone.LocalTimezone())
                     sg_publish["created_at"] = created_at
 


### PR DESCRIPTION
This cropped up during Max 2017 compatibility testing. Passing a datetime object to the string formatter results in a TypeError being raised. Handling it here in a backwards-compatible way.