### PR TITLE
For #38434 and #38433, better context change handling

### DIFF
--- a/hooks/scene_operation_tk-shell.py
+++ b/hooks/scene_operation_tk-shell.py
@@ -70,5 +70,5 @@ class SceneOperation(HookClass):
             return True
         elif operation == "open":
             return QtGui.QMessageBox.question(
-                None, "", "Are you sure?", QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
+                None, "", "Are you sure you want to open?", QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
             ) == QtGui.QMessageBox.Yes

--- a/hooks/scene_operation_tk-shell.py
+++ b/hooks/scene_operation_tk-shell.py
@@ -11,19 +11,19 @@
 import os
 
 import sgtk
+from sgtk.platform.qt import QtGui
 
 HookClass = sgtk.get_hook_baseclass()
 
 
 class SceneOperation(HookClass):
     """
-    Hook called to perform an operation with the
-    current scene
+    Hook called to perform an operation with the current scene.
     """
 
     def execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
         """
-        Main hook entry point
+        Main hook entry point.
 
         :param operation:       String
                                 Scene operation to perform
@@ -68,4 +68,7 @@ class SceneOperation(HookClass):
             return os.getcwd()
         elif operation == "reset":
             return True
-
+        elif operation == "open":
+            return QtGui.QMessageBox.question(
+                None, "", "Are you sure?", QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
+            ) == QtGui.QMessageBox.Yes

--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -108,10 +108,12 @@ class FileAction(Action):
         Set context to the new context.
 
         :param ctx: The :class:`sgtk.Context` to change to.
+
+        :raises TankError: Raised when the context change fails.
         """
         app = sgtk.platform.current_bundle()
         app.log_info("Changing context from %s to %s" % (app.context, ctx))
-        
+
         # Change context.
         QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         try:
@@ -121,7 +123,29 @@ class FileAction(Action):
             raise TankError("Failed to change work area - %s" % e)
         finally:
             QtGui.QApplication.restoreOverrideCursor()
-    
+
+    @staticmethod
+    def restore_context(parent_ui, ctx):
+        """
+        Utility method to restore the original context when a file operation failed.
+
+        A dialog will display the error if the restoration fails. This method is exception safe.
+
+        :param PySide.QtWidget parent_ui: Parent for the error dialog, if needed.
+        :param sgtk.Context ctx: Context to restore.
+        """
+        app = sgtk.platform.current_bundle()
+        app.log_debug("Restoring context.")
+        try:
+            FileAction.change_context(ctx)
+        except Exception, e:
+            QtGui.QMessageBox.critical(
+                parent_ui,
+                "Unable to restore the original context",
+                "Failed to change the work area back to '%s':\n\n%s\n\nUnable to continue!" % (ctx, e)
+            )
+            app.log_exception("Failed to change the work area back to %s!" % ctx)
+
     def __init__(self, label, file, file_versions, environment):
         """
         """

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -108,6 +108,7 @@ class OpenFileAction(FileAction):
                 return False            
                     
         # switch context:
+        previous_context = self._app.context
         if not new_ctx == self._app.context:
             try:
                 # Change the curent context.
@@ -120,16 +121,39 @@ class OpenFileAction(FileAction):
 
         # open file
         try:
-            open_file(self._app, OPEN_FILE_ACTION, new_ctx, dst_path, version, read_only)
+            is_file_opened = open_file(self._app, OPEN_FILE_ACTION, new_ctx, dst_path, version, read_only)
         except Exception, e:
             QtGui.QMessageBox.critical(parent_ui, "Failed to open file", 
                                        "Failed to open file\n\n%s\n\n%s" % (dst_path, e))
-            self._app.log_exception("Failed to open file %s!" % dst_path)    
+            self._app.log_exception("Failed to open file %s!" % dst_path)
+            self._restore_context(parent_ui, previous_context)
             return False
-        
+        # Test specifically for False. Legacy open hooks return None, which means success.
+        if is_file_opened is False:
+            self._restore_context(parent_ui, previous_context)
+            return False
+
         return True
-    
-    
+
+    def _restore_context(self, parent_ui, ctx):
+        """
+        Restore the original context. A dialog will display the error if the restoration fails.
+
+        :param PySide.QtWidget parent_ui: Parent for the error dialog, if needed.
+        :param sgtk.Context ctx: Context to restore.
+        """
+        self._app.log_debug("Restoring context.")
+        try:
+            FileAction.change_context(ctx)
+        except Exception, e:
+            QtGui.QMessageBox.critical(
+                parent_ui,
+                "Unable to restore the original context", 
+                "Failed to change the work area back to '%s':\n\n%s\n\nUnable to continue!" % (ctx, e)
+            )
+            self._app.log_exception("Failed to change the work area back to %s!" % ctx)
+
+
 class CopyAndOpenInCurrentWorkAreaAction(OpenFileAction):
     """
     """

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -126,32 +126,14 @@ class OpenFileAction(FileAction):
             QtGui.QMessageBox.critical(parent_ui, "Failed to open file", 
                                        "Failed to open file\n\n%s\n\n%s" % (dst_path, e))
             self._app.log_exception("Failed to open file %s!" % dst_path)
-            self._restore_context(parent_ui, previous_context)
+            FileAction.restore_context(parent_ui, previous_context)
             return False
         # Test specifically for False. Legacy open hooks return None, which means success.
         if is_file_opened is False:
-            self._restore_context(parent_ui, previous_context)
+            FileAction.restore_context(parent_ui, previous_context)
             return False
 
         return True
-
-    def _restore_context(self, parent_ui, ctx):
-        """
-        Restore the original context. A dialog will display the error if the restoration fails.
-
-        :param PySide.QtWidget parent_ui: Parent for the error dialog, if needed.
-        :param sgtk.Context ctx: Context to restore.
-        """
-        self._app.log_debug("Restoring context.")
-        try:
-            FileAction.change_context(ctx)
-        except Exception, e:
-            QtGui.QMessageBox.critical(
-                parent_ui,
-                "Unable to restore the original context", 
-                "Failed to change the work area back to '%s':\n\n%s\n\nUnable to continue!" % (ctx, e)
-            )
-            self._app.log_exception("Failed to change the work area back to %s!" % ctx)
 
 
 class CopyAndOpenInCurrentWorkAreaAction(OpenFileAction):

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -32,6 +32,7 @@ class SaveAsFileAction(FileAction):
             return False
 
         # switch context:
+        previous_context = self._app.context
         if not self.environment.context == self._app.context:
             try:
                 # Change the current context
@@ -51,10 +52,11 @@ class SaveAsFileAction(FileAction):
 
         # and save the current file as the new path:
         try:
-            save_file(self._app, SAVE_FILE_AS_ACTION,  self.environment.context, self.file.path)
+            save_file(self._app, SAVE_FILE_AS_ACTION, self.environment.context, self.file.path)
         except Exception, e:
             QtGui.QMessageBox.critical(None, "Failed to save file!", "Failed to save file:\n\n%s" % e)
             self._app.log_exception("Failed to save file!")
+            FileAction.restore_context(parent_ui, previous_context)
             return False
 
         return True

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -65,7 +65,7 @@ def _do_scene_operation(app, action, context, operation, path=None, version=0, r
     if result_types and not isinstance(result, result_types):
         raise TankError(
             ("Unexpected type returned from 'hook_scene_operation' "
-             "for operation '%s' - expected one of %s but returned '%s'")
+             "for operation '%s' - expected one of (%s) but returned '%s'")
             % (
                 operation,
                 ", ".join([rtype.__name__ for rtype in result_types]),


### PR DESCRIPTION
If an open or save hook fails, we now revert back to the original context. Also, when opening a scene, the hook can now return False to indicate that the hook refused to open the file. The context is then reverted as well.

We only use change_context in non-exception safe ways in the open and save action. The New action is correct.