### PR TITLE
For #38554, sandbox constant refresh fix

### DIFF
--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -71,7 +71,6 @@ class BrowserForm(QtGui.QWidget):
         monitor_qobject_lifetime(self._file_filters, "Browser file filters")
         self._file_filters.users_changed.connect(self._on_file_filters_users_changed)
 
-
     def shut_down(self):
         """
         Help the gc by cleaning up as much as possible when this widget is finished with
@@ -95,6 +94,7 @@ class BrowserForm(QtGui.QWidget):
             self._file_model = None
 
             # clean up the file filters:
+
             self._file_filters = None
         finally:
             self.blockSignals(signals_blocked)
@@ -175,7 +175,7 @@ class BrowserForm(QtGui.QWidget):
         if file_model:
             # attach file model to the file views:
             self._file_model = file_model
-            self._file_model.available_sandbox_users_changed.connect(self._on_available_sandbox_users_changed)
+            self._file_model.sandbox_users_found.connect(self._on_sandbox_users_found)
             self._file_model.uses_user_sandboxes.connect(self._on_uses_user_sandboxes)
             self._file_model.set_users(self._file_filters.users)
 
@@ -263,16 +263,16 @@ class BrowserForm(QtGui.QWidget):
     # ------------------------------------------------------------------------------------------
     # protected methods
 
-    def _on_available_sandbox_users_changed(self, users):
+    def _on_sandbox_users_found(self, users):
         """
         Called when the list of sandbox users available for a given selection has been updated
-        after parsing each context.
+        in the model after parsing the context's directories.
 
         :param users: Array of user entity dictionary.
         """
         app = sgtk.platform.current_bundle()
-        app.log_debug("Available sandbox users: %s" % [u["name"].split()[0] for u in users if u])
-        self._file_filters.available_users = users
+        app.log_debug("Sandbox users found: %s" % [u["name"].split()[0] for u in users if u])
+        self._file_filters.add_users(users)
 
     def _on_file_filters_users_changed(self, users):
         """
@@ -296,6 +296,9 @@ class BrowserForm(QtGui.QWidget):
         """
         # build breadcrumb trail for the current selection in the UI:
         breadcrumb_trail = []
+
+        # Clear the list of available users for the current selection.
+        #self._file_filters.clear_available_users()
 
         tab_index = self._ui.task_browser_tabs.currentIndex()
         tab_label = value_to_str(self._ui.task_browser_tabs.tabText(tab_index))

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -298,7 +298,7 @@ class BrowserForm(QtGui.QWidget):
         breadcrumb_trail = []
 
         # Clear the list of available users for the current selection.
-        #self._file_filters.clear_available_users()
+        self._file_filters.clear_available_users()
 
         tab_index = self._ui.task_browser_tabs.currentIndex()
         tab_label = value_to_str(self._ui.task_browser_tabs.tabText(tab_index))

--- a/python/tk_multi_workfiles/file_filters.py
+++ b/python/tk_multi_workfiles/file_filters.py
@@ -1,33 +1,34 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 Collection of filters to be used when filtering files in the file views.
 """
 
-import sgtk
 from sgtk.platform.qt import QtCore
 
 from .user_cache import g_user_cache
+
 
 class FileFilters(QtCore.QObject):
     """
     Implementation of the FileFilters class
     """
+
     # signal emitted whenever something in the filters is changed
     changed = QtCore.Signal()
     # signal emitted whenever the available users are changed
     available_users_changed = QtCore.Signal(object)# list of users
     # signal emitted whenever the users changed:
     users_changed = QtCore.Signal(object)# list of users
-    
+
     def __init__(self, parent):
         """
         Construction
@@ -35,36 +36,41 @@ class FileFilters(QtCore.QObject):
         :param parent:  The parent QObject
         """
         QtCore.QObject.__init__(self, parent)
-        
+
         self._show_all_versions = False
         self._filter_reg_exp = QtCore.QRegExp()
         self._available_users = [g_user_cache.current_user] if g_user_cache.current_user else []
         self._users = [g_user_cache.current_user] if g_user_cache.current_user else []
 
-    #@property
+    # @property
     def _get_show_all_versions(self):
         return self._show_all_versions
-    #@show_all_versions.setter
+
+    # @show_all_versions.setter
     def _set_show_all_versions(self, show):
         if show != self._show_all_versions:
             self._show_all_versions = show
             self.changed.emit()
-    show_all_versions=property(_get_show_all_versions, _set_show_all_versions)
 
-    #@property filter_reg_exp
+    show_all_versions = property(_get_show_all_versions, _set_show_all_versions)
+
+    # @property filter_reg_exp
     def _get_filter_reg_exp(self):
         return self._filter_reg_exp
-    #@filter_reg_exp.setter
+
+    # @filter_reg_exp.setter
     def _set_filter_reg_exp(self, value):
         if value != self._filter_reg_exp:
             self._filter_reg_exp = value
             self.changed.emit()
+
     filter_reg_exp = property(_get_filter_reg_exp, _set_filter_reg_exp)
 
-    #@property
+    # @property
     def _get_available_users(self):
         return self._available_users
-    #available_users.setter
+
+    # available_users.setter
     def _set_available_users(self, users):
         current_user_ids = set([u["id"] for u in self._available_users if u])
         new_user_ids = set([u["id"] for u in users if u])
@@ -77,10 +83,11 @@ class FileFilters(QtCore.QObject):
             self._set_users(self._users)
     available_users = property(_get_available_users, _set_available_users)
 
-    #@property
+    # @property
     def _get_users(self):
         return self._users
-    #users.setter
+
+    # users.setter
     def _set_users(self, users):
         current_user_ids = set([u["id"] for u in self._users if u])
         available_user_ids = set([u["id"] for u in self._available_users])
@@ -89,8 +96,5 @@ class FileFilters(QtCore.QObject):
             self._users = [u for u in users if u and u["id"] in new_user_ids]
             self.users_changed.emit(self._users)
             self.changed.emit()
+
     users = property(_get_users, _set_users)
-
-
-
-

--- a/python/tk_multi_workfiles/file_filters.py
+++ b/python/tk_multi_workfiles/file_filters.py
@@ -77,6 +77,7 @@ class FileFilters(QtCore.QObject):
         Clear the list of available user sandboxes.
         """
         self._reset_user_lists()
+        self.available_users_changed.emit(self._available_users)
 
     def _reset_user_lists(self):
         self._available_users = [g_user_cache.current_user] if g_user_cache.current_user else []

--- a/python/tk_multi_workfiles/file_filters.py
+++ b/python/tk_multi_workfiles/file_filters.py
@@ -86,6 +86,8 @@ class FileFilters(QtCore.QObject):
     def add_users(self, users):
         """
         Adds to the list of available user sandboxes.
+
+        :param users: List of users dictionaries.
         """
         nb_users_before = len(self._available_users)
 
@@ -95,8 +97,8 @@ class FileFilters(QtCore.QObject):
         available_users_by_id.update(new_users_by_id)
         self._available_users = available_users_by_id.values()
 
-        # Something was added to the set.
-        if nb_users_before != len(self._available_users):
+        # The updated dictionary has grown, so something new was added!
+        if len(self._available_users) > nb_users_before:
             self.available_users_changed.emit(self._available_users)
 
     # @property

--- a/python/tk_multi_workfiles/file_filters.py
+++ b/python/tk_multi_workfiles/file_filters.py
@@ -39,8 +39,7 @@ class FileFilters(QtCore.QObject):
 
         self._show_all_versions = False
         self._filter_reg_exp = QtCore.QRegExp()
-        self._available_users = [g_user_cache.current_user] if g_user_cache.current_user else []
-        self._users = [g_user_cache.current_user] if g_user_cache.current_user else []
+        self._reset_user_lists()
 
     # @property
     def _get_show_all_versions(self):
@@ -66,22 +65,38 @@ class FileFilters(QtCore.QObject):
 
     filter_reg_exp = property(_get_filter_reg_exp, _set_filter_reg_exp)
 
-    # @property
-    def _get_available_users(self):
+    @property
+    def available_users(self):
+        """
+        :returns: List of available user sandboxes.
+        """
         return self._available_users
 
-    # available_users.setter
-    def _set_available_users(self, users):
-        current_user_ids = set([u["id"] for u in self._available_users if u])
-        new_user_ids = set([u["id"] for u in users if u])
-        if new_user_ids != current_user_ids:
-            self._available_users = [u for u in users if u]
-            self.available_users_changed.emit(self._available_users)
+    def clear_available_users(self):
+        """
+        Clear the list of available user sandboxes.
+        """
+        self._reset_user_lists()
 
-            # also, update user ids, removing any that are no longer in
-            # the list of available user ids:
-            self._set_users(self._users)
-    available_users = property(_get_available_users, _set_available_users)
+    def _reset_user_lists(self):
+        self._available_users = [g_user_cache.current_user] if g_user_cache.current_user else []
+        self._users = [g_user_cache.current_user] if g_user_cache.current_user else []
+
+    def add_users(self, users):
+        """
+        Adds to the list of available user sandboxes.
+        """
+        nb_users_before = len(self._available_users)
+
+        # merge the two lists, discarding doubles.
+        new_users_by_id = {user["id"]: user for user in users}
+        available_users_by_id = {user["id"]: user for user in self._available_users}
+        available_users_by_id.update(new_users_by_id)
+        self._available_users = available_users_by_id.values()
+
+        # Something was added to the set.
+        if nb_users_before != len(self._available_users):
+            self.available_users_changed.emit(self._available_users)
 
     # @property
     def _get_users(self):

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -1,29 +1,29 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import weakref
 
 import sgtk
 from sgtk.platform.qt import QtGui, QtCore
-from sgtk import TankError
-
-shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
-ShotgunDataRetriever = shotgun_data.ShotgunDataRetriever
 
 from .file_finder import AsyncFileFinder
 from .user_cache import g_user_cache
 from .file_search_cache import FileSearchCache
 
+shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
+ShotgunDataRetriever = shotgun_data.ShotgunDataRetriever
+
+
 class FileModel(QtGui.QStandardItemModel):
     """
-    The FileModel maintains a model of all files (work files and publishes) found for a matrix of 
+    The FileModel maintains a model of all files (work files and publishes) found for a matrix of
     entities and users.  Details of each 'version' of a file are contained in a FileItem instance
     and presented as a single model item.
 
@@ -32,14 +32,15 @@ class FileModel(QtGui.QStandardItemModel):
 
     Additional items are added to a group to represent additional hierarchy in the model.
     """
+
     class SearchDetails(object):
         """
         Representation of details needed to search for a set of files.  A single instance
         of this class represents a single entity to be grouped in the model
         """
+
         def __init__(self, name=None):
             """
-            Construction
             :param name:    The string name to be used for the search.  This is used when constructing
                             the group name in the model.
             """
@@ -75,17 +76,16 @@ class FileModel(QtGui.QStandardItemModel):
         """
         Base model item for storage of the file data in the model.
         """
+
         def __init__(self, typ, text=None):
             """
-            Construction
-
             :param typ:     The type of item this represents (see enumeration of node types above)
             :param text:    String used for the label/display role for this item
             """
             QtGui.QStandardItem.__init__(self, text or "")
             self._type = typ
 
-        def data(self, role=QtCore.Qt.UserRole+1):
+        def data(self, role=QtCore.Qt.UserRole + 1):
             """
             Return the data from the item for the specified role.
 
@@ -98,7 +98,7 @@ class FileModel(QtGui.QStandardItemModel):
                 # just return the default implementation:
                 return QtGui.QStandardItem.data(self, role)
 
-        def setData(self, value, role=QtCore.Qt.UserRole+1):
+        def setData(self, value, role=QtCore.Qt.UserRole + 1):
             """
             Set the data on the item for the specified role
 
@@ -110,16 +110,15 @@ class FileModel(QtGui.QStandardItemModel):
                 pass
             else:
                 # call the base implementation:
-                QtGui.QStandardItem.setData(self, value, role) 
+                QtGui.QStandardItem.setData(self, value, role)
 
     class _FileModelItem(_BaseModelItem):
         """
         Model item that represents a single FileItem in the model
         """
+
         def __init__(self, file_item, work_area):
             """
-            Construction
-
             :param file_item:    The FileItem instance this model item represents
             :param work_area:    The WorkArea this file item belongs to
             """
@@ -141,7 +140,7 @@ class FileModel(QtGui.QStandardItemModel):
             """
             return self._work_area
 
-        def data(self, role=QtCore.Qt.UserRole+1):
+        def data(self, role=QtCore.Qt.UserRole + 1):
             """
             Return the data from the item for the specified role.
 
@@ -158,7 +157,7 @@ class FileModel(QtGui.QStandardItemModel):
                 # just return the default implementation:
                 return FileModel._BaseModelItem.data(self, role)
 
-        def setData(self, value, role=QtCore.Qt.UserRole+1):
+        def setData(self, value, role=QtCore.Qt.UserRole + 1):
             """
             Set the data on the item for the specified role
 
@@ -176,17 +175,16 @@ class FileModel(QtGui.QStandardItemModel):
                 self.emitDataChanged()
             else:
                 # call the base implementation:
-                FileModel._BaseModelItem.setData(self, value, role) 
+                FileModel._BaseModelItem.setData(self, value, role)
 
     class _FolderModelItem(_BaseModelItem):
         """
         Model item that represents a folder in the model.  These are used when a group has entity
         children that need to be represented in the model.
         """
+
         def __init__(self, name, entity):
             """
-            Construction
-
             :param name:    The name to use for the model item display role
             :param entity:  A Shotgun entity dictionary for the entity that this folder item represents
             """
@@ -205,10 +203,9 @@ class FileModel(QtGui.QStandardItemModel):
         Model item that represents a group in the model.  A group is a per-user, per-entity item that contains
         the files found for the group as well as any additional child entities.
         """
+
         def __init__(self, name, key, work_area=None):
             """
-            Construction
-
             :param name:        The name to use for the model items display role
             :param key:         A unique key representing this group
             :param work_area:   A WorkArea instance that this group represents
@@ -227,13 +224,14 @@ class FileModel(QtGui.QStandardItemModel):
             """
             return self._key
 
-        #@property
+        # @property
         def _get_work_area(self):
             """
             :returns:   The WorkArea instance associated with this item
             """
             return self._work_area
-        #@work_area.setter
+
+        # @work_area.setter
         def _set_work_area(self, work_area):
             """
             Set the work area associated with this item
@@ -242,7 +240,8 @@ class FileModel(QtGui.QStandardItemModel):
             """
             self._work_area = work_area
             self.emitDataChanged()
-        work_area=property(_get_work_area, _set_work_area)
+
+        work_area = property(_get_work_area, _set_work_area)
 
         def set_search_status(self, status, msg=None):
             """
@@ -255,7 +254,7 @@ class FileModel(QtGui.QStandardItemModel):
             self._search_msg = msg
             self.emitDataChanged()
 
-        def data(self, role=QtCore.Qt.UserRole+1):
+        def data(self, role=QtCore.Qt.UserRole + 1):
             """
             Return the data from the item for the specified role.
 
@@ -272,7 +271,7 @@ class FileModel(QtGui.QStandardItemModel):
                 # just return the default implementation:
                 return FileModel._BaseModelItem.data(self, role)
 
-        def setData(self, value, role=QtCore.Qt.UserRole+1):
+        def setData(self, value, role=QtCore.Qt.UserRole + 1):
             """
             Set the data on the item for the specified role
 
@@ -290,7 +289,7 @@ class FileModel(QtGui.QStandardItemModel):
                 self.emitDataChanged()
             else:
                 # call the base implementation:
-                FileModel._BaseModelItem.setData(self, value, role) 
+                FileModel._BaseModelItem.setData(self, value, role)
 
     # Signal emitted when sandboxes are used, but before we know which ones
     uses_user_sandboxes = QtCore.Signal(object) # Work area that uses sandboxes.
@@ -299,8 +298,6 @@ class FileModel(QtGui.QStandardItemModel):
 
     def __init__(self, bg_task_manager, parent):
         """
-        Construction
-
         :param bg_task_manager: A BackgroundTaskManager instance that will be used for all background/threaded
                                 work that needs undertaking
         :param parent:          The parent QObject for this instance
@@ -340,7 +337,7 @@ class FileModel(QtGui.QStandardItemModel):
 
     def destroy(self):
         """
-        Called to clean-up and shutdown any internal objects when the model has been finished 
+        Called to clean-up and shutdown any internal objects when the model has been finished
         with.  Failure to call this may result in instability or unexpected behaviour!
         """
         # clear the model:
@@ -375,14 +372,14 @@ class FileModel(QtGui.QStandardItemModel):
 
         :param key:         The unique file key to find file versions for
         :param work_area:   A WorkArea instance to find file versions for
-        :param clean_only:  If true then the cached file versions will only be returned if the cache is 
+        :param clean_only:  If true then the cached file versions will only be returned if the cache is
                             up-to-date.  If false then file versions will be returned even if the model is still
                             searching for files.
         :returns:           A dictionary {version:FileItem} of all file versions found.
         """
         return self._search_cache.find_file_versions(work_area, key, clean_only)
 
-    def items_from_file(self, file_item, ignore_version = False):
+    def items_from_file(self, file_item, ignore_version=False):
         """
         Find the model item(s) for the specified file item.
 
@@ -398,7 +395,7 @@ class FileModel(QtGui.QStandardItemModel):
     # Interface for modifying the entities in the model:
     def set_entity_searches(self, searches):
         """
-        Set the entity searches that the model should populate itself with.  The model will 
+        Set the entity searches that the model should populate itself with.  The model will
         be updated to contain a group item for each search+user combination and will initiate a
         search for all files (work files and publishes) in this group.
 
@@ -419,8 +416,8 @@ class FileModel(QtGui.QStandardItemModel):
     # Interface for modifying the users in the model:
     def set_users(self, users):
         """
-        Set the users the model should populate itself with.  The model will be updated to contain a group 
-        item for each search+user combination and will initiate a search for all files (work files and 
+        Set the users the model should populate itself with.  The model will be updated to contain a group
+        item for each search+user combination and will initiate a search for all files (work files and
         publishes) in this group.
 
         :param users:    A list of Shotgun user dictionaries that should be represented in the model
@@ -436,7 +433,7 @@ class FileModel(QtGui.QStandardItemModel):
                 self._current_users.insert(0, g_user_cache.current_user)
         elif not self._current_users:
             # no users so use 'None' instead which will effectively search for the
-            # current user but handles the legacy case where the current user doesn't 
+            # current user but handles the legacy case where the current user doesn't
             # match the log-in!
             self._current_users = [None]
 
@@ -538,7 +535,7 @@ class FileModel(QtGui.QStandardItemModel):
 
     def _file_items(self, parent_item):
         """
-        Iterate over all child items for the specified parent and yield all _FileModelItems that 
+        Iterate over all child items for the specified parent and yield all _FileModelItems that
         are found
 
         :param parent_item: The parent item to yield _FileModelItems for
@@ -613,9 +610,9 @@ class FileModel(QtGui.QStandardItemModel):
         Update groups in the model.  Remove any that are no longer needed and insert any that are
         needed but are missing.
 
-        This will ensure that _all_ groups are added for the current user but groups for other users 
-        are only added if/when files are found unless they already exist in which case they are left 
-        in the model.  This provides the most consistent experience for any views hooked up to the 
+        This will ensure that _all_ groups are added for the current user but groups for other users
+        are only added if/when files are found unless they already exist in which case they are left
+        in the model.  This provides the most consistent experience for any views hooked up to the
         model.
         """
         # get existing groups:
@@ -723,8 +720,8 @@ class FileModel(QtGui.QStandardItemModel):
                 entities_to_add.append((child_name, child_entity))
 
         # figure out which rows to remove...
-        rows_to_remove = set([row for key, row in current_entity_row_map.iteritems() 
-                                if key not in valid_gen_entity_keys])
+        rows_to_remove = set([row for key, row in current_entity_row_map.iteritems()
+                              if key not in valid_gen_entity_keys])
         # and remove them:
         for row in sorted(rows_to_remove, reverse=True):
             self._safe_remove_row(row, parent_item)
@@ -807,17 +804,19 @@ class FileModel(QtGui.QStandardItemModel):
             # if one is available:
             if file_item.is_published and file_item.thumbnail_path and not file_item.thumbnail:
                 # request the thumbnail using the data retriever:
-                request_id = self._sg_data_retriever.request_thumbnail(file_item.thumbnail_path, 
-                                                                       self._published_file_type, 
+                request_id = self._sg_data_retriever.request_thumbnail(file_item.thumbnail_path,
+                                                                       self._published_file_type,
                                                                        file_item.published_file_id,
                                                                        "image",
-                                                                       load_image = True)
+                                                                       load_image=True)
                 self._pending_thumbnail_requests[request_id] = (group_item.key, file_item.key, file_item.version)
 
         # figure out if any existing items are no longer needed:
         valid_file_versions = set(valid_files.keys())
         file_versions_to_remove = set(existing_file_item_map.keys()) - valid_file_versions
-        rows_to_remove = set([v[1].row() for k, v in existing_file_item_map.iteritems() if k in file_versions_to_remove])
+        rows_to_remove = set(
+            [v[1].row() for k, v in existing_file_item_map.iteritems() if k in file_versions_to_remove]
+        )
 
         # update any files that are no longer in the corresponding set but which aren't going to be removed:
         if have_local:
@@ -892,7 +891,7 @@ class FileModel(QtGui.QStandardItemModel):
                 if item:
                     found_items.append(item)
         return found_items
- 
+
     def _find_file_items(self, file_map, file_key, file_version):
         """
         Find current model items for the specified file key and version in the specified map.  If file key
@@ -922,7 +921,7 @@ class FileModel(QtGui.QStandardItemModel):
         :param group_key:       The group key to find all matching items for
         :param file_key:        The file key to find all matching items for
         :param file_version:    The file version to find all matching items for
-        :returns:               A list of _FileModelItems that were found that match the specified group key, 
+        :returns:               A list of _FileModelItems that were found that match the specified group key,
                                 file key and file version
         """
         found_items = []
@@ -1022,8 +1021,8 @@ class FileModel(QtGui.QStandardItemModel):
         :param file_list:    The list of FileItems that were found
         :param work_area:    The work area that the files were found in
         """
-        self._app.log_debug("File Model: Found %d files for search %s, user '%s'" 
-                            % (len(file_list), search_id, 
+        self._app.log_debug("File Model: Found %d files for search %s, user '%s'"
+                            % (len(file_list), search_id,
                                work_area.context.user["name"] if work_area.context.user else "Unknown"))
         self._process_found_files(search_id, file_list, work_area, have_local=True, have_publishes=False)
 
@@ -1035,8 +1034,8 @@ class FileModel(QtGui.QStandardItemModel):
         :param file_list:    The list of FileItems that were found
         :param work_area:    The work area that the publishes were found in
         """
-        self._app.log_debug("File Model: Found %d publishes for search %s, user '%s'" 
-                            % (len(file_list), search_id, 
+        self._app.log_debug("File Model: Found %d publishes for search %s, user '%s'"
+                            % (len(file_list), search_id,
                                work_area.context.user["name"] if work_area.context.user else "Unknown"))
         self._process_found_files(search_id, file_list, work_area, have_local=False, have_publishes=True)
 
@@ -1086,7 +1085,7 @@ class FileModel(QtGui.QStandardItemModel):
 
     def _on_finder_search_completed(self, search_id):
         """
-        Slot triggered when a finder search has completed.  This gets called once all search 
+        Slot triggered when a finder search has completed.  This gets called once all search
         tasks have been completed successfully.
 
         :param search_id:   The id of the search that has completed
@@ -1199,8 +1198,8 @@ class FileModel(QtGui.QStandardItemModel):
 
     def _update_group_file_items(self, group_item):
         """
-        Update all file model items within the specified group model item.  This updates each file's 
-        tooltip, associated versions and thumbnail and ensures that the correct dataChanged signal is 
+        Update all file model items within the specified group model item.  This updates each file's
+        tooltip, associated versions and thumbnail and ensures that the correct dataChanged signal is
         emitted for them.
 
         :param group_item:  The _GroupModelItem representing the group in the model
@@ -1247,7 +1246,7 @@ class FileModel(QtGui.QStandardItemModel):
         # emit data changed signal for all items in the group:
         row_count = group_item.rowCount()
         tl_idx = self.index(0, 0, group_item.index())
-        br_idx = self.index(row_count-1, 0, group_item.index())
+        br_idx = self.index(row_count - 1, 0, group_item.index())
         self.dataChanged.emit(tl_idx, br_idx)
 
     def _update_version_thumbnails(self, file_key, group_key, work_area):
@@ -1289,28 +1288,28 @@ class FileModel(QtGui.QStandardItemModel):
             return
 
         # make sure the thumbnail is a good size with the correct aspect ratio:
-        MAX_WIDTH = 576#96
-        MAX_HEIGHT = 374#64
-        ASPECT = float(MAX_WIDTH)/MAX_HEIGHT
+        MAX_WIDTH = 576 # 96
+        MAX_HEIGHT = 374 # 64
+        ASPECT = float(MAX_WIDTH) / MAX_HEIGHT
 
         thumb_sz = thumb.size()
-        thumb_aspect = float(thumb_sz.width())/thumb_sz.height()
+        thumb_aspect = float(thumb_sz.width()) / thumb_sz.height()
         max_thumb_sz = QtCore.QSize(MAX_WIDTH, MAX_HEIGHT)
         if thumb_aspect >= ASPECT:
             # scale based on width:
             if thumb_sz.width() > MAX_WIDTH:
-                thumb_sz *= (float(MAX_WIDTH)/thumb_sz.width())
+                thumb_sz *= (float(MAX_WIDTH) / thumb_sz.width())
             else:
-                max_thumb_sz *= (float(thumb_sz.width())/MAX_WIDTH)
+                max_thumb_sz *= (float(thumb_sz.width()) / MAX_WIDTH)
         else:
             # scale based on height:
             if thumb_sz.height() > MAX_HEIGHT:
-                thumb_sz *= (float(MAX_HEIGHT)/thumb_sz.height())
+                thumb_sz *= (float(MAX_HEIGHT) / thumb_sz.height())
             else:
-                max_thumb_sz *= (float(thumb_sz.height())/MAX_HEIGHT)
+                max_thumb_sz *= (float(thumb_sz.height()) / MAX_HEIGHT)
 
         if thumb_sz != thumb.size():
-            thumb = thumb.scaled(thumb_sz.width(), thumb_sz.height(), 
+            thumb = thumb.scaled(thumb_sz.width(), thumb_sz.height(),
                                  QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
 
         # create base pixmap with the correct aspect ratio that the thumbnail will fit in
@@ -1325,7 +1324,7 @@ class FileModel(QtGui.QStandardItemModel):
 
             # paint the thumbnail into this base making sure it's centered:
             diff = max_thumb_sz - thumb.size()
-            offset = diff/2
+            offset = diff / 2
             brush = QtGui.QBrush(thumb)
             painter.setBrush(brush)
             painter.translate(offset.width(), offset.height())
@@ -1334,6 +1333,3 @@ class FileModel(QtGui.QStandardItemModel):
             painter.end()
 
         return thumb_base
-
-
-

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -85,7 +85,7 @@ class FileModel(QtGui.QStandardItemModel):
             QtGui.QStandardItem.__init__(self, text or "")
             self._type = typ
 
-        def data(self, role=QtCore.Qt.UserRole + 1):
+        def data(self, role):
             """
             Return the data from the item for the specified role.
 
@@ -98,7 +98,7 @@ class FileModel(QtGui.QStandardItemModel):
                 # just return the default implementation:
                 return QtGui.QStandardItem.data(self, role)
 
-        def setData(self, value, role=QtCore.Qt.UserRole + 1):
+        def setData(self, value, role):
             """
             Set the data on the item for the specified role
 
@@ -140,7 +140,7 @@ class FileModel(QtGui.QStandardItemModel):
             """
             return self._work_area
 
-        def data(self, role=QtCore.Qt.UserRole + 1):
+        def data(self, role):
             """
             Return the data from the item for the specified role.
 
@@ -157,7 +157,7 @@ class FileModel(QtGui.QStandardItemModel):
                 # just return the default implementation:
                 return FileModel._BaseModelItem.data(self, role)
 
-        def setData(self, value, role=QtCore.Qt.UserRole + 1):
+        def setData(self, value, role):
             """
             Set the data on the item for the specified role
 
@@ -254,7 +254,7 @@ class FileModel(QtGui.QStandardItemModel):
             self._search_msg = msg
             self.emitDataChanged()
 
-        def data(self, role=QtCore.Qt.UserRole + 1):
+        def data(self, role):
             """
             Return the data from the item for the specified role.
 
@@ -271,7 +271,7 @@ class FileModel(QtGui.QStandardItemModel):
                 # just return the default implementation:
                 return FileModel._BaseModelItem.data(self, role)
 
-        def setData(self, value, role=QtCore.Qt.UserRole + 1):
+        def setData(self, value, role):
             """
             Set the data on the item for the specified role
 

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -293,8 +293,8 @@ class FileModel(QtGui.QStandardItemModel):
 
     # Signal emitted when sandboxes are used, but before we know which ones
     uses_user_sandboxes = QtCore.Signal(object) # Work area that uses sandboxes.
-    # Signal emitted when the available sandbox users have changed
-    available_sandbox_users_changed = QtCore.Signal(list)# list of users
+    # Signal emitted when the sandbox_users_found when users were found in the sandbox.
+    sandbox_users_found = QtCore.Signal(list)# list of users
 
     def __init__(self, bg_task_manager, parent):
         """
@@ -316,7 +316,6 @@ class FileModel(QtGui.QStandardItemModel):
         # in this model.
         self._current_searches = []
         self._current_users = [g_user_cache.current_user]
-        self._entity_work_area_map = {}
 
         self._in_progress_searches = {}
         self._search_cache = FileSearchCache()
@@ -973,8 +972,7 @@ class FileModel(QtGui.QStandardItemModel):
     def _on_finder_work_area_resolved(self, search_id, work_area):
         """
         Slot triggered when the finder resolved users from a work area during the search.  If the work area
-        contains user sandboxes this will emit the available_sandbox_users_changed signal with the
-        list of users.
+        contains user sandboxes this will emit the sandbox_users_found signal with the list of users.
 
         :param search_id:    The id of the search that the work area was resolved for
         :param work_area:    The WorkArea instance that was resolved
@@ -983,35 +981,11 @@ class FileModel(QtGui.QStandardItemModel):
             # ignore result
             return
 
-        search = self._in_progress_searches[search_id]
-        entity_key = self._gen_entity_key(search.entity)
+        users = list(work_area.sandbox_users)
 
-        # keep track of work area for this entity:
-        self._entity_work_area_map[entity_key] = work_area
-
-        # consolidate list of sandbox users for all current work areas:
-        have_user_sandboxes = False
-        users_by_id = {}
-        handled_entities = set()
-        for search in self._in_progress_searches.values():
-            entity_key = self._gen_entity_key(search.entity)
-            if entity_key in handled_entities:
-                continue
-            handled_entities.add(entity_key)
-
-            area = self._entity_work_area_map.get(entity_key)
-            if area and area.contains_user_sandboxes:
-                have_user_sandboxes = True
-                for user in area.sandbox_users:
-                    if user:
-                        users_by_id[user["id"]] = user
-
-        # and current user is _always_ available:
-        if g_user_cache.current_user:
-            users_by_id[g_user_cache.current_user["id"]] = g_user_cache.current_user
-
-        if have_user_sandboxes:
-            self.available_sandbox_users_changed.emit(users_by_id.values())
+        # If users were found.
+        if users:
+            self.sandbox_users_found.emit(users)
 
     def _on_finder_files_found(self, search_id, file_list, work_area):
         """


### PR DESCRIPTION
This fixes an issue where different contexts with different sandboxes would update the sandbox user list in random fashion and the last update won. It took a while to figure this out since user sandboxes are usually created on all steps so the sandboxes are the same for every context. However, Task folders are created on demand and therefore the list of sandboxes per context is different and that's the scenario that caused an issue.

The fix is simple. We'll simply assume that any updates to the sandbox users list is additive and we'll clear the list on selection change.

I recommend skipping the first commit since it is only whitespace changes on comment lines and easy PEP8 fixes.