### PR TITLE
#38761 Tree view sorted alphabetically

### DIFF
--- a/python/tk_multi_workfiles/entity_tree/entity_tree_proxy_model.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_proxy_model.py
@@ -13,17 +13,25 @@
 
 import sgtk
 from ..entity_proxy_model import EntityProxyModel
+from sgtk.platform.qt import QtCore
 
 from ..user_cache import g_user_cache
 
 class EntityTreeProxyModel(EntityProxyModel):
     """
+    Proxy model that handles searching and sorting of the
+    left hand side entity hierarchies.
     """
+
     def __init__(self, parent, compare_sg_fields):
         """
         """
         EntityProxyModel.__init__(self, parent, compare_sg_fields)
         self._only_show_my_tasks = False
+
+        # set proxy to auto sort alphabetically
+        self.setDynamicSortFilter(True)
+        self.sort(0, QtCore.Qt.AscendingOrder)
 
     #@property
     def _get_only_show_my_tasks(self):


### PR DESCRIPTION
The left hand side tree view is now sorted alphabetically:

![image](https://cloud.githubusercontent.com/assets/337710/20429938/7fed62ca-ad89-11e6-9cc4-8d65c9557fbc.png)

Previously, it would just display the raw data as it was being sent from the shotgun model. The shotgun model does not imply any ordering of the data, this is left to the client to handle (since it typically varies between use cases and sometimes, like in the case of the loader, you want to do a bunch of post processing of the raw model data before you have access to the display name which you want to order by).