### PR TITLE
Changes to workfiles to work with new defer loaded sg model

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -196,6 +196,6 @@ supported_engines:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}    
     

--- a/python/tk_multi_workfiles/entity_proxy_model.py
+++ b/python/tk_multi_workfiles/entity_proxy_model.py
@@ -25,27 +25,12 @@ class EntityProxyModel(HierarchicalFilteringProxyModel):
         HierarchicalFilteringProxyModel.__init__(self, parent)
         self._compare_fields = compare_sg_fields
 
-    def __ensure_subtree_loaded(self, model_index):
-        """
-        Recursively descend and ensure all data is
-        fetched for the given model index.
-
-        :param model_index: Model index to process
-        """
-        model = model_index.model()
-        if model.canFetchMore(model_index):
-            model.fetchMore(model_index)
-        for child_index in range(model.rowCount(model_index)):
-            child_model_index = model.index(child_index, 0, parent=model_index)
-            self.__ensure_subtree_loaded(child_model_index)
-
     def setFilterFixedString(self, pattern):
         """
         Overriden base class method to set the filter fixed string
         """
         # ensure model is fully loaded before we attempt any searching
-        root_index = self.sourceModel().invisibleRootItem().index()
-        self.__ensure_subtree_loaded(root_index)
+        self.sourceModel().ensure_data_is_loaded()
 
         # call base class
         return super(EntityProxyModel, self).setFilterFixedString(pattern)
@@ -55,8 +40,7 @@ class EntityProxyModel(HierarchicalFilteringProxyModel):
         Overriden base class method to set the filter regular expression
         """
         # ensure model is fully loaded before we attempt any searching
-        root_index = self.sourceModel().invisibleRootItem().index()
-        self.__ensure_subtree_loaded(root_index)
+        self.sourceModel().ensure_data_is_loaded()
 
         # call base class
         return super(EntityProxyModel, self).setFilterRegExp(reg_exp)

--- a/python/tk_multi_workfiles/entity_proxy_model.py
+++ b/python/tk_multi_workfiles/entity_proxy_model.py
@@ -25,6 +25,42 @@ class EntityProxyModel(HierarchicalFilteringProxyModel):
         HierarchicalFilteringProxyModel.__init__(self, parent)
         self._compare_fields = compare_sg_fields
 
+    def __ensure_subtree_loaded(self, model_index):
+        """
+        Recursively descend and ensure all data is
+        fetched for the given model index.
+
+        :param model_index: Model index to process
+        """
+        model = model_index.model()
+        if model.canFetchMore(model_index):
+            model.fetchMore(model_index)
+        for child_index in range(model.rowCount(model_index)):
+            child_model_index = model.index(child_index, 0, parent=model_index)
+            self.__ensure_subtree_loaded(child_model_index)
+
+    def setFilterFixedString(self, pattern):
+        """
+        Overriden base class method to set the filter fixed string
+        """
+        # ensure model is fully loaded before we attempt any searching
+        root_index = self.sourceModel().invisibleRootItem().index()
+        self.__ensure_subtree_loaded(root_index)
+
+        # call base class
+        return super(EntityProxyModel, self).setFilterFixedString(pattern)
+
+    def setFilterRegExp(self, reg_exp):
+        """
+        Overriden base class method to set the filter regular expression
+        """
+        # ensure model is fully loaded before we attempt any searching
+        root_index = self.sourceModel().invisibleRootItem().index()
+        self.__ensure_subtree_loaded(root_index)
+
+        # call base class
+        return super(EntityProxyModel, self).setFilterRegExp(reg_exp)
+
     def _is_row_accepted(self, src_row, src_parent_idx, parent_accepted):
         """
         Overriden from base class - determines if the specified row should be accepted or not by

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -316,15 +316,7 @@ class EntityTreeForm(QtGui.QWidget):
             return {}
 
         # first, ensure that all child data has been loaded
-        def __fetch_more_r(model_index):
-            """Recursively descend and ensure all data is fetched"""
-            model = model_index.model()
-            if model.canFetchMore(model_index):
-                model.fetchMore(model_index)
-            for child_index in range(model.rowCount(model_index)):
-                child_model_index = model.index(child_index, 0, parent=model_index)
-                __fetch_more_r(child_model_index)
-        __fetch_more_r(idx)
+        idx.model().ensure_data_is_loaded(idx)
 
         item = self._item_from_index(idx)
         entity_model = get_source_model(idx.model())

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -316,14 +316,15 @@ class EntityTreeForm(QtGui.QWidget):
             return {}
 
         # first, ensure that all child data has been loaded
-        def __fetch_more_r(model_index, model):
+        def __fetch_more_r(model_index):
             """Recursively descend and ensure all data is fetched"""
+            model = model_index.model()
             if model.canFetchMore(model_index):
                 model.fetchMore(model_index)
             for child_index in range(model.rowCount(model_index)):
                 child_model_index = model.index(child_index, 0, parent=model_index)
-                __fetch_more_r(child_model_index, model)
-        __fetch_more_r(idx, idx.model())
+                __fetch_more_r(child_model_index)
+        __fetch_more_r(idx)
 
         item = self._item_from_index(idx)
         entity_model = get_source_model(idx.model())

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -315,6 +315,16 @@ class EntityTreeForm(QtGui.QWidget):
         if not idx.isValid():
             return {}
 
+        # first, ensure that all child data has been loaded
+        def __fetch_more_r(model_index, model):
+            """Recursively descend and ensure all data is fetched"""
+            if model.canFetchMore(model_index):
+                model.fetchMore(model_index)
+            for child_index in range(model.rowCount(model_index)):
+                child_model_index = model.index(child_index, 0, parent=model_index)
+                __fetch_more_r(child_model_index, model)
+        __fetch_more_r(idx, idx.model())
+
         item = self._item_from_index(idx)
         entity_model = get_source_model(idx.model())
         if not item or not entity_model:


### PR DESCRIPTION
Previously, workfiles assumed that the tree structure on the left hand side was always fully loaded. The new optimized shotgun model defer loads stuff into memory for performance and this caused workfiles to not get all the child data correctly when an item in the left hand side tree was clicked. 
This fix adds a recursive load of child data just in time before it's needed, ensuring consistent behaviour when running with the new optimized sg model.

The filtering logic has been updated to ensure the entire tree is fetched just in time prior to filtering.

This change is backwards compatible and will not affect users running against older versions of the sg model but it is required if you want to run with the latest optimized version.