### PR TITLE
Update open_file_action.py

### DIFF
--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -51,13 +51,6 @@ class OpenFileAction(FileAction):
         if not dst_path or not new_ctx:
             # can't do anything!
             return False
-           
-        if src_path and src_path != dst_path:
-            # check that the source path exists:        
-            if not os.path.exists(src_path):
-                QtGui.QMessageBox.critical(parent_ui, "File doesn't exist!", 
-                                           "The file\n\n%s\n\nCould not be found to open!" % src_path)
-                return False
             
         if new_ctx != self._app.context:
             # ensure folders exist.  This serves the


### PR DESCRIPTION
Having this check for if the source file exists locally prevents workflows where perforce/FTP or similar is used to fetch the published file as needed in the copy_file hook that is called later. I suggest moving the check to the copy_file hook to open up the possibility to not have the published file available locally