### PR TITLE
Adds option to hide published files.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -1,11 +1,11 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Metadata defining the behaviour and requirements for this app
@@ -19,8 +19,8 @@ configuration:
     launch_at_startup:
         type: bool
         description: A flag whether to launch the UI at application startup.
-                     This option is not supported on all engines because of 
-                     differences in the way some platforms start up. Currently, only maya 
+                     This option is not supported on all engines because of
+                     differences in the way some platforms start up. Currently, only maya
                      nuke and 3ds Max support this option.
         default_value: False
 
@@ -57,20 +57,20 @@ configuration:
     hook_scene_operation:
         type: hook
         default_value: "{self}/scene_operation_{engine_name}.py"
-        description: All the application specific scene operations (open, save etc) that 
+        description: All the application specific scene operations (open, save etc) that
                      the app needs to carry out are collected together in this hook.
-        
+
     hook_copy_file:
         type: hook
         default_value: "{self}/copy_file.py"
-        description: Specify a hook that will be used to copy the file 'source_path' 
+        description: Specify a hook that will be used to copy the file 'source_path'
                      to 'target_path'.
 
     hook_filter_work_files:
         type: hook
         default_value: "{self}/filter_work_files.py"
         description: Specify a hook that, if needed, can filter the raw list of work files found
-                     for the current work area 
+                     for the current work area
 
     hook_filter_publishes:
         type: hook
@@ -146,10 +146,10 @@ configuration:
     version_compare_ignore_fields:
       type: list
       description:  A list of fields that should be ignored when comparing files to
-                    determine if they are different versions of the same file.  If 
+                    determine if they are different versions of the same file.  If
                     this is left empty then only the version field will be ignored.
-                    Care should be taken when specifying fields to ignore as Toolkit 
-                    will expect the version to be unique across files that have 
+                    Care should be taken when specifying fields to ignore as Toolkit
+                    will expect the version to be unique across files that have
                     different values for those fields and will error if this isn't the
                     case.
       values:
@@ -160,6 +160,11 @@ configuration:
     allow_task_creation:
         type: bool
         description: Controls whether new tasks can be created from the app.
+        default_value: True
+
+    show_published_files:
+        type: bool
+        description: Define if published workfiles should be shown.
         default_value: True
 
     # Save specific options
@@ -173,29 +178,29 @@ configuration:
 
     saveas_prefer_version_up:
       type: bool
-      description: Control how the save-as command determines the inital name to be used.  If 
-                   set to True then the name from the current scene will be used and the version 
-                   incremented.  If False then a new unique name will be used and the version 
+      description: Control how the save-as command determines the inital name to be used.  If
+                   set to True then the name from the current scene will be used and the version
+                   incremented.  If False then a new unique name will be used and the version
                    reset
       default_value: False
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 
-# More verbose description of this item 
+# More verbose description of this item
 display_name: "Shotgun Workfiles"
 description: "Using this app you can browse, open and save your Work Files and Publishes."
-              
+
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.17.0"
 requires_engine_version:
 
 # the engines that this app can operate in:
-supported_engines: 
+supported_engines:
 
 # the frameworks required to run this app
 frameworks:
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}
-    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}    
-    
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}
+

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -179,10 +179,19 @@ class BrowserForm(QtGui.QWidget):
             self._file_model.uses_user_sandboxes.connect(self._on_uses_user_sandboxes)
             self._file_model.set_users(self._file_filters.users)
 
-            # add an 'all files' tab:
-            self._add_file_list_form("All", "All Files", show_work_files=True, show_publishes=True )
+            # add an 'all files' tab if Publishes will be shown:
+            show_published_files = app.get_setting("show_published_files")
+            if show_published_files:
+                self._add_file_list_form("All", "All Files", show_work_files=True, show_publishes=True )
+
             self._add_file_list_form("Working", "Work Files", show_work_files=True, show_publishes=False)
-            self._add_file_list_form("Publishes", "Publishes", show_work_files=False, show_publishes=True)
+
+            # if publishes aren't going to be shown then skip adding it and hide
+            # the tabbar.
+            if show_published_files:
+                self._add_file_list_form("Publishes", "Publishes", show_work_files=False, show_publishes=True)
+            else:
+                self._ui.file_browser_tabs.tabBar().hide()
 
     def _add_file_list_form(self, tab_name, search_label, show_work_files, show_publishes):
         """

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -278,15 +278,19 @@ class WorkArea(object):
         :returns: An array of sgtk.Template objects that are not configured.
         """
         # First find all the templates that are not defined.
+        app = sgtk.platform.current_bundle()
         missing_templates = []
         if not self.work_area_template:
             missing_templates.append("'template_work_area'")
         if not self.work_template:
             missing_templates.append("'template_work'")
-        if not self.publish_area_template:
-            missing_templates.append("'template_publish_area'")
-        if not self.publish_template:
-            missing_templates.append("'template_publish'")
+
+        # Only check for these templates if show_published_files is True.
+        if app.get_setting("show_published_files"):
+            if not self.publish_area_template:
+                missing_templates.append("'template_publish_area'")
+            if not self.publish_template:
+                missing_templates.append("'template_publish'")
 
         return missing_templates
 
@@ -460,7 +464,7 @@ class WorkArea(object):
             # from the path and then inspect the user from this
             path_ctx = app.sgtk.context_from_path(path)
             user = path_ctx.user
-            if user: 
+            if user:
                 user_ids.add(user["id"])
 
         # look these up in the user cache:


### PR DESCRIPTION
This patch adds an option (show_published_files) which when set to False will disable and hide published files appearing in the tool. This also removes the requirement of having published file templates filled out in order to save workfiles.

Please see issue #38 for more details.