### PR TITLE
#42449 Usability tweaks to improve working with large amounts of tasks

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -140,15 +140,14 @@ configuration:
       default_value: []
 
     my_tasks_filters:
-      type: dict
+      type: list
       description: List of filters to apply to the tasks in the My Tasks tab.
       values:
-        type: list
+        type: shotgun_filter
       allows_empty: True
       default_value:
-        filters:
-          - [task_assignees, is, '{context.user}']
-          - [sg_status_list, not_in, [fin,omt]]
+        - [task_assignees, is, '{context.user}']
+        - [sg_status_list, not_in, [fin,omt]]
 
     file_extensions:
         type: list

--- a/info.yml
+++ b/info.yml
@@ -129,7 +129,7 @@ configuration:
     auto_expand_tree:
         type: bool
         description: Automatically expands the root level of the treeviews.
-        default_value: True
+        default_value: False
 
     my_tasks_extra_display_fields:
       type: list

--- a/info.yml
+++ b/info.yml
@@ -126,6 +126,11 @@ configuration:
         default_value: True
         default_value_tk-hiero: False
 
+    auto_expand_tree:
+        type: bool
+        description: Automatically expands the root level of the treeviews.
+        default_value: True
+
     my_tasks_extra_display_fields:
       type: list
       description: List of additional fields to display with the task in the My Tasks list.
@@ -133,6 +138,14 @@ configuration:
         type: str
       allows_empty: True
       default_value: []
+
+    my_tasks_filter_statuses:
+      type: list
+      description: List of additional fields to display with the task in the My Tasks list.
+      values:
+        type: str
+      allows_empty: True
+      default_value: [fin,omt]
 
     file_extensions:
         type: list

--- a/info.yml
+++ b/info.yml
@@ -139,13 +139,16 @@ configuration:
       allows_empty: True
       default_value: []
 
-    my_tasks_filter_statuses:
-      type: list
-      description: List of additional fields to display with the task in the My Tasks list.
+    my_tasks_filters:
+      type: dict
+      description: List of filters to apply to the tasks in the My Tasks tab.
       values:
-        type: str
+        type: list
       allows_empty: True
-      default_value: [fin,omt]
+      default_value:
+        filters:
+          - [task_assignees, is, '{context.user}']
+          - [sg_status_list, not_in, [fin,omt]]
 
     file_extensions:
         type: list

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -80,13 +80,14 @@ class EntityTreeForm(QtGui.QWidget):
 
         # load the setting that states whether the first level of the tree should be auto expanded
         app = sgtk.platform.current_bundle()
-        self._auto_expand_tree = app.get_setting("auto_expand_tree", True)
+        self._auto_expand_tree = app.get_setting("auto_expand_tree")
 
         # set up the UI
         self._ui = Ui_EntityTreeForm()
         self._ui.setupUi(self)
 
         self._ui.search_ctrl.set_placeholder_text("Search %s" % search_label)
+        self._ui.search_ctrl.setToolTip("Press enter to complete the search")
 
         # enable/hide the my-tasks-only button if we are showing tasks:
         have_tasks = (entity_model and entity_model.get_entity_type() == "Task")

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -78,6 +78,10 @@ class EntityTreeForm(QtGui.QWidget):
         self._expanded_items = set()
         self._auto_expanded_root_items = set()
 
+        # load the setting that states whether the first level of the tree should be auto expanded
+        app = sgtk.platform.current_bundle()
+        self._auto_expand_tree = app.get_setting("auto_expand_tree", True)
+
         # set up the UI
         self._ui = Ui_EntityTreeForm()
         self._ui.setupUi(self)
@@ -117,7 +121,7 @@ class EntityTreeForm(QtGui.QWidget):
                 self._ui.entity_tree.setModel(filter_model)
 
                 # connect up the filter controls:
-                self._ui.search_ctrl.search_edited.connect(self._on_search_changed)
+                self._ui.search_ctrl.search_changed.connect(self._on_search_changed)
                 self._ui.my_tasks_cb.toggled.connect(self._on_my_tasks_only_toggled)
             else:
                 self._ui.entity_tree.setModel(entity_model)
@@ -542,6 +546,10 @@ class EntityTreeForm(QtGui.QWidget):
         """
         view_model = self._ui.entity_tree.model()
         if not view_model:
+            return
+
+        # check if we should automatically expand the root level of the tree
+        if not self._auto_expand_tree:
             return
 
         # disable widget paint updates whilst we update the expanded state of the tree:

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -121,9 +121,8 @@ class FileFormBase(QtGui.QWidget):
 
         # get any extra display fields we'll need to retrieve:
         extra_display_fields = app.get_setting("my_tasks_extra_display_fields")
-        # get the my task filters from the config. It is dictionary containing a single
-        # 'filters' key that contains a list. This due to the core not validating a list of lists
-        my_tasks_filters = app.get_setting("my_tasks_filters",{}).get('filters',[])
+        # get the my task filters from the config.
+        my_tasks_filters = app.get_setting("my_tasks_filters")
 
         # create the model:
         model = MyTasksModel(app.context.project,

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -33,7 +33,7 @@ from .file_item import FileItem
 from .work_area import WorkArea
 from .actions.new_task_action import NewTaskAction
 from .user_cache import g_user_cache
-from .util import monitor_qobject_lifetime
+from .util import monitor_qobject_lifetime, resolve_filters
 
 
 class FileFormBase(QtGui.QWidget):
@@ -121,13 +121,15 @@ class FileFormBase(QtGui.QWidget):
 
         # get any extra display fields we'll need to retrieve:
         extra_display_fields = app.get_setting("my_tasks_extra_display_fields")
-        my_tasks_filter_statuses = app.get_setting("my_tasks_filter_statuses",["fin"])
+        # get the my task filters from the config. It is dictionary containing a single
+        # 'filters' key that contains a list. This due to the core not validating a list of lists
+        my_tasks_filters = app.get_setting("my_tasks_filters",{}).get('filters',[])
 
         # create the model:
         model = MyTasksModel(app.context.project,
                              g_user_cache.current_user,
                              extra_display_fields,
-                             my_tasks_filter_statuses,
+                             my_tasks_filters,
                              parent=self,
                              bg_task_manager=self._bg_task_manager)
         monitor_qobject_lifetime(model, "My Tasks Model")
@@ -142,28 +144,6 @@ class FileFormBase(QtGui.QWidget):
                     in the app configuration
         """
         app = sgtk.platform.current_bundle()
-
-        def resolve_filters(filters):
-            resolved_filters = []
-            for filter in filters:
-                if type(filter) is dict:
-                    resolved_filter = {
-                        "filter_operator": filter["filter_operator"],
-                        "filters": resolve_filters(filter["filters"])}
-                else:
-                    resolved_filter = []
-                    for field in filter:
-                        if field == "{context.entity}":
-                            field = app.context.entity
-                        elif field == "{context.step}":
-                            field = app.context.step
-                        elif field == "{context.task}":
-                            field = app.context.task
-                        elif field == "{context.user}":
-                            field = app.context.user
-                        resolved_filter.append(field)
-                resolved_filters.append(resolved_filter)
-            return resolved_filters
 
         entity_models = []
 

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -121,11 +121,13 @@ class FileFormBase(QtGui.QWidget):
 
         # get any extra display fields we'll need to retrieve:
         extra_display_fields = app.get_setting("my_tasks_extra_display_fields")
+        my_tasks_filter_statuses = app.get_setting("my_tasks_filter_statuses",["fin"])
 
         # create the model:
         model = MyTasksModel(app.context.project,
                              g_user_cache.current_user,
                              extra_display_fields,
+                             my_tasks_filter_statuses,
                              parent=self,
                              bg_task_manager=self._bg_task_manager)
         monitor_qobject_lifetime(model, "My Tasks Model")

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_model.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_model.py
@@ -15,6 +15,8 @@ Implementation of the 'My Tasks' data model
 import sgtk
 from sgtk.platform.qt import QtGui
 
+from ..util import resolve_filters
+
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 ShotgunEntityModel = shotgun_model.ShotgunEntityModel
 
@@ -24,7 +26,7 @@ class MyTasksModel(ShotgunEntityModel):
     from the Shotgun entity model so that we have access to the entity icons it provides.  These are used 
     later by the MyTaskItemDelegate when rending a widget for a task in the My Tasks view.
     """
-    def __init__(self, project, user, extra_display_fields, my_tasks_filter_statuses, parent, bg_task_manager=None):
+    def __init__(self, project, user, extra_display_fields, my_tasks_filters, parent, bg_task_manager=None):
         """
         Construction
 
@@ -38,9 +40,10 @@ class MyTasksModel(ShotgunEntityModel):
                                         background threaded work.
         """
         self.extra_display_fields = extra_display_fields or []
-        filters = [["project", "is", project],
-                   ["task_assignees", "is", user],
-                   ["sg_status_list", "not_in", my_tasks_filter_statuses]]
+
+        filters = [["project", "is", project]]
+        filters.extend(resolve_filters(my_tasks_filters))
+
         fields = ["image", "entity", "content"]
         fields.extend(self.extra_display_fields)
 

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_model.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_model.py
@@ -24,7 +24,7 @@ class MyTasksModel(ShotgunEntityModel):
     from the Shotgun entity model so that we have access to the entity icons it provides.  These are used 
     later by the MyTaskItemDelegate when rending a widget for a task in the My Tasks view.
     """
-    def __init__(self, project, user, extra_display_fields, parent, bg_task_manager=None):
+    def __init__(self, project, user, extra_display_fields, my_tasks_filter_statuses, parent, bg_task_manager=None):
         """
         Construction
 
@@ -39,7 +39,8 @@ class MyTasksModel(ShotgunEntityModel):
         """
         self.extra_display_fields = extra_display_fields or []
         filters = [["project", "is", project],
-                   ["task_assignees", "is", user]]
+                   ["task_assignees", "is", user],
+                   ["sg_status_list", "not_in", my_tasks_filter_statuses]]
         fields = ["image", "entity", "content"]
         fields.extend(self.extra_display_fields)
 

--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -261,3 +261,28 @@ def get_template_user_keys(template):
         if key.shotgun_entity_type == "HumanUser":
             user_keys.add(key.name)
     return user_keys
+
+
+def resolve_filters(filters):
+    app = sgtk.platform.current_bundle()
+
+    resolved_filters = []
+    for filter in filters:
+        if type(filter) is dict:
+            resolved_filter = {
+                "filter_operator": filter["filter_operator"],
+                "filters": resolve_filters(filter["filters"])}
+        else:
+            resolved_filter = []
+            for field in filter:
+                if field == "{context.entity}":
+                    field = app.context.entity
+                elif field == "{context.step}":
+                    field = app.context.step
+                elif field == "{context.task}":
+                    field = app.context.task
+                elif field == "{context.user}":
+                    field = app.context.user
+                resolved_filter.append(field)
+        resolved_filters.append(resolved_filter)
+    return resolved_filters

--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -264,6 +264,16 @@ def get_template_user_keys(template):
 
 
 def resolve_filters(filters):
+    """
+    
+    When passed a list of filters, it will resolve strings found in the filters using the context
+    example: '{context.user}' could get resolved to {'type': 'HumanUser', 'id': 86, 'name': 'Philip Scadding'} 
+    
+    :param filters: a list of filters as found in the info.yml config
+    should be in the format: [[task_assignees, is, '{context.user}'],[sg_status_list, not_in, [fin,omt]]]
+    
+    :return: A List of filters for use with the shotgun api
+    """
     app = sgtk.platform.current_bundle()
 
     resolved_filters = []


### PR DESCRIPTION
#42449
#42445
#39615

Made some changes that hopefully make working with large amounts of tasks a bit easier.
More work is still needed, but these can be considered quick fixes.

Added option to disable auto expansion of root level in the tree views.

- You can now set a`auto_expand_tree` key on the app config to true or false, to toggle this behaviour

Added option to set a list of status that the My Tasks tab will use as a filter to exclude.

- can now set a config key for `my_tasks_filter_statuses: ['fin','omt']` to filter out tasks from the "my tasks" tab, with the status codes listed.

Changed tree view search box behaviour so that it only performs the search after hitting enter.
This helps when performing the search is very slow, as it will now only perform the search after enter is hit, rather than every character entered.