### PR TITLE
Allow to use fields in saveas_default_name option. 

### DIFF
--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -587,7 +587,7 @@ class FileSaveForm(FileFormBase):
                 name_is_optional = name_is_used and self._current_env.work_template.is_optional("name")
                 if not name and not name_is_optional:
                     # lets populate name with a default value:
-                    name = self._current_env.save_as_default_name.format(**env.context.as_template_fields(self._current_env.work_template))
+                    name = self._current_env.save_as_default_name.format(**env.context.as_template_fields(self._current_env.work_template)) or "scene"
                 self._ui.name_edit.setText(name)
 
             self._ui.name_label.setVisible(name_is_used)

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -539,7 +539,7 @@ class FileSaveForm(FileFormBase):
             if not name and not name_is_optional:
                 # need to use either the current name if we have it or the default if we don't!
                 current_name = value_to_str(self._ui.name_edit.text())
-                default_name = self._current_env.save_as_default_name
+                default_name = self._current_env.save_as_default_name.format(**fields)
                 name = current_name or default_name or "scene"
 
             self._ui.name_edit.setText(name)
@@ -587,7 +587,7 @@ class FileSaveForm(FileFormBase):
                 name_is_optional = name_is_used and self._current_env.work_template.is_optional("name")
                 if not name and not name_is_optional:
                     # lets populate name with a default value:
-                    name = self._current_env.save_as_default_name or "scene"
+                    name = self._current_env.save_as_default_name.format(**env.context.as_template_fields(self._current_env.work_template))
                 self._ui.name_edit.setText(name)
 
             self._ui.name_label.setVisible(name_is_used)


### PR DESCRIPTION
@ Benuts, 

We decided to work with root templates such as those:
    shot_root: sequences/{Sequence}/{Shot}/{Step}/{task_name}
    asset_root: assets/{sg_asset_type}/{Asset}/{Step}/{task_name}

So it's convenient for us to be able to set the" saveas_default_name" to the task name dinamically.
In order to be able to do this, I patched the file_save_form.py

Eg: saveas_default_name: '{Step}'. In our case, we use {task_name}.