### PR TITLE
#44390 Modified the file widget layout to account for long filenames.

### DIFF
--- a/python/tk_multi_workfiles/file_list/file_list_item_delegate.py
+++ b/python/tk_multi_workfiles/file_list/file_list_item_delegate.py
@@ -57,20 +57,24 @@ class FileListItemDelegate(GroupedListViewItemDelegate):
 
         # get the data for the model index:
         label = ""
+        subtitle = ""
         icon = None
+        show_subtitle = False
         item_type = get_model_data(model_index, FileModel.NODE_TYPE_ROLE)
         if item_type == FileModel.FILE_NODE_TYPE:
 
             is_publish = False
             is_editable = True
+            show_subtitle = True
             file_item = get_model_data(model_index, FileModel.FILE_ITEM_ROLE)
             if file_item:
-                # build label:
-                label = "<b>%s, v%03d</b>" % (file_item.name, file_item.version)
+                # build labels:
+                label = "<b>%s<b>" % file_item.name
+                subtitle += "v%03d" % file_item.version
                 if file_item.is_published:
-                    label += "<br>%s" % file_item.format_published_by_details()
+                    subtitle += "<br>%s" % file_item.format_published_by_details()
                 elif file_item.is_local:
-                    label += "<br>%s" % file_item.format_modified_by_details()
+                    subtitle += "<br>%s" % file_item.format_modified_by_details()
 
                 # retrieve the icon:
                 icon = file_item.thumbnail
@@ -90,6 +94,8 @@ class FileListItemDelegate(GroupedListViewItemDelegate):
 
         # update the widget:
         widget.title = label
+        widget.subtitle = subtitle
+        widget.set_show_subtitle(show_subtitle)
         widget.set_thumbnail(icon)
         widget.selected = (style_options.state & QtGui.QStyle.State_Selected) == QtGui.QStyle.State_Selected
 

--- a/python/tk_multi_workfiles/file_list/file_widget.py
+++ b/python/tk_multi_workfiles/file_list/file_widget.py
@@ -76,6 +76,21 @@ class FileWidget(QtGui.QWidget):
         self._update_ui()
     selected=property(_get_selected, _set_selected)
 
+    def _get_subtitle(self):
+        return self._ui.subtitle.text()
+
+    def _set_subtitle(self, value):
+        self._ui.subtitle.setText(value)
+    subtitle = property(_get_subtitle, _set_subtitle)
+
+    def set_show_subtitle(self, show_subtitle):
+        """
+        Set if the widget's subtitle should be displayed.
+
+        :param show_subtitle: True if the subtitle should be displayed, otherwise False
+        """
+        self._ui.subtitle.setVisible(show_subtitle)
+
     def set_is_publish(self, is_publish):
         """
         """

--- a/python/tk_multi_workfiles/ui/file_widget.py
+++ b/python/tk_multi_workfiles/ui/file_widget.py
@@ -60,13 +60,16 @@ class Ui_FileWidget(object):
         self.verticalLayout.setObjectName("verticalLayout")
         spacerItem = QtGui.QSpacerItem(20, 0, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.verticalLayout.addItem(spacerItem)
-        self.label = QtGui.QLabel(self.background)
+        self.label = ElidedLabel(self.background)
         self.label.setObjectName("label")
         self.verticalLayout.addWidget(self.label)
+        self.subtitle = QtGui.QLabel(self.background)
+        self.subtitle.setObjectName("subtitle")
+        self.verticalLayout.addWidget(self.subtitle)
         spacerItem1 = QtGui.QSpacerItem(20, 0, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.verticalLayout.addItem(spacerItem1)
         self.verticalLayout.setStretch(0, 1)
-        self.verticalLayout.setStretch(2, 1)
+        self.verticalLayout.setStretch(3, 1)
         self.horizontalLayout_2.addLayout(self.verticalLayout)
         self.horizontalLayout_2.setStretch(1, 1)
         self.horizontalLayout.addWidget(self.background)
@@ -77,5 +80,7 @@ class Ui_FileWidget(object):
     def retranslateUi(self, FileWidget):
         FileWidget.setWindowTitle(QtGui.QApplication.translate("FileWidget", "Form", None, QtGui.QApplication.UnicodeUTF8))
         self.label.setText(QtGui.QApplication.translate("FileWidget", "<b>Title</b>", None, QtGui.QApplication.UnicodeUTF8))
+        self.subtitle.setText(QtGui.QApplication.translate("FileWidget", "Subtitle", None, QtGui.QApplication.UnicodeUTF8))
 
+from ..framework_qtwidgets import ElidedLabel
 from . import resources_rc

--- a/resources/file_widget.ui
+++ b/resources/file_widget.ui
@@ -94,7 +94,7 @@ border-radius: 2px;
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
+       <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0,1">
         <property name="spacing">
          <number>2</number>
         </property>
@@ -112,9 +112,16 @@ border-radius: 2px;
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="ElidedLabel" name="label">
           <property name="text">
            <string>&lt;b&gt;Title&lt;/b&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="subtitle">
+          <property name="text">
+           <string>Subtitle</string>
           </property>
          </widget>
         </item>
@@ -138,6 +145,13 @@ border-radius: 2px;
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ElidedLabel</class>
+   <extends>QLabel</extends>
+   <header>..framework_qtwidgets</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="resources.qrc"/>
  </resources>


### PR DESCRIPTION
Currently, if filenames exceed approximately 23 characters (varies in Nuke and Maya), the file browser list displays them as truncated names. This sometimes also causes the version information to be hidden. 
eg.
<img width="600" alt="screen shot 2017-09-19 at 3 07 11 pm" src="https://user-images.githubusercontent.com/7693347/30617797-9032545c-9d4c-11e7-9e42-007a7a5d85d6.png">

This PR attempts to resolve this issue by making the following layout modifications to the file widget:
* The work file name now displays an ellipsis to indicate that it is longer than it appears to be. The tooltip should show the full name of the file.
* The version is now listed on the following line (instead of comma-separated `name, v001`).

Like so
<img width="585" alt="screen shot 2017-09-19 at 3 08 55 pm" src="https://user-images.githubusercontent.com/7693347/30617800-92b70a10-9d4c-11e7-804e-23299566f3a4.png">


