### PR TITLE
removed infinite while loop in folder creation

### DIFF
--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -84,7 +84,7 @@ class FileAction(Action):
                 if template_keys <= ctx_keys:
                     # we've found the longest template that contains only context fields
                     break
-                ctx_template = template.parent
+                ctx_template = ctx_template.parent
                 
             if not ctx_template:
                 # couldn't figure out the path to test so assume that we need to create folders:


### PR DESCRIPTION
Workfiles FileAction would hang indefinitely as the template it was trying to resolve was always pointing back to the same one.