### PR TITLE
For #41520: Eliminates noise on app launch in Photoshop.

### DIFF
--- a/hooks/scene_operation_tk-photoshopcc.py
+++ b/hooks/scene_operation_tk-photoshopcc.py
@@ -60,15 +60,7 @@ class SceneOperation(HookClass):
 
         if operation == "current_path":
             # return the current script path
-            doc = self._get_active_document()
-
-            if doc.fullName is None:
-                # new file?
-                path = ""
-            else:
-                path = doc.fullName.fsName
-
-            return path
+            return adobe.get_active_document_path() or ""
 
         elif operation == "open":
             # open the specified script
@@ -97,9 +89,9 @@ class SceneOperation(HookClass):
         Returns the currently open document in Photoshop.
         Raises an exeption if no document is active.
         """
-        try:
-            doc = self.parent.engine.adobe.app.activeDocument
-        except RuntimeError:
+        doc = self.parent.engine.adobe.get_active_document()
+
+        if not doc:
             raise TankError("There is no active document!")
 
         return doc


### PR DESCRIPTION
The photoshopcc hook handled exceptions raised by the tk-photoshopcc RPC API, but it didn't keep the logged exception from making its way into the console via logging. The Adobe bridge class in the engine does all of this for us via some convenience methods, so this is moving the hook to using those instead of implementing similar logic locally.