### PR TITLE
For #38483, improved refresh.

### DIFF
--- a/python/tk_multi_workfiles/entity_models/deferred_model.py
+++ b/python/tk_multi_workfiles/entity_models/deferred_model.py
@@ -527,6 +527,12 @@ class ShotgunDeferredEntityModel(ShotgunExtendedEntityModel):
         # sets, then things changed.
         if existing_uids ^ refreshed_uids:
             self._post_delayed_data_refreshed()
+        elif len(refreshed_uids) == 1 and self._dummy_placeholder_item_uid(parent_item) in refreshed_uids:
+            # Special case if we just have the dummy placeholder: the same item
+            # is kept but its value changed, e.g. "Retrieving..." to "No xx found"
+            # this value is used by the file browser tab so we need to notify it
+            # to update itself.
+            self._post_delayed_data_refreshed()
 
     def _post_delayed_data_refreshed(self):
         """

--- a/python/tk_multi_workfiles/entity_models/extended_model.py
+++ b/python/tk_multi_workfiles/entity_models/extended_model.py
@@ -130,6 +130,10 @@ class ShotgunExtendedEntityModel(ShotgunEntityModel):
             self._hierarchy,
             self._fields
         )
+        # If we loaded something from the cache notify viewers that new data is
+        # already available.
+        if self.invisibleRootItem().rowCount():
+            self.data_refreshed.emit(True)
         self.async_refresh()
 
     def _finalize_item(self, item):

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -86,10 +86,6 @@ class EntityTreeForm(QtGui.QWidget):
         self._expanded_item_values = []
         self._selected_item_value = []
 
-        # An overlay widget we can hide and show when the model is being refreshed.
-        # This is mainly used as a workaround for 3ds 2016 refresh problems: by
-        # hiding the widget when the data is refreshed, the UI is properly refreshed.
-        self._refresh_overlay_widget = overlay_widget.ShotgunSpinningWidget(self)
 
         # load the setting that states whether the first level of the tree should be auto expanded
         app = sgtk.platform.current_bundle()
@@ -99,6 +95,10 @@ class EntityTreeForm(QtGui.QWidget):
         self._ui = Ui_EntityTreeForm()
         self._ui.setupUi(self)
 
+        # An overlay widget we can hide and show when the model is being refreshed.
+        # This is mainly used as a workaround for 3ds 2016 refresh problems: by
+        # hiding the widget when the data is refreshed, the UI is properly refreshed.
+        self._refresh_overlay_widget = overlay_widget.ShotgunOverlayWidget(self._ui.entity_tree)
         self._ui.search_ctrl.set_placeholder_text("Search %s" % search_label)
         self._ui.search_ctrl.setToolTip("Press enter to complete the search")
 
@@ -627,9 +627,8 @@ class EntityTreeForm(QtGui.QWidget):
         # try to select the current entity from the new items in the model:
         prev_selected_item = self._reset_selection()
         self._update_selection(prev_selected_item, True)
-        # Hide the overlay widget, if it was visible
-        if not self._refresh_overlay_widget.isHidden():
-            self._refresh_overlay_widget.hide()
+        # Hide the overlay widget
+        self._refresh_overlay_widget.hide()
 
     def _expand_root_rows(self):
         """


### PR DESCRIPTION
Couple of fixes related to refreshing the model:

* In classic mode, emit a data changed as soon as some cached data is loaded, instead of waiting for the async refresh to trigger a data changed callback.
* Fixed the overlay widget by using the right widget and the right parent.
* Refresh the file browser when no entities are found after a deferred model refresh.