### PR TITLE
Feature/tab settings

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -206,6 +206,14 @@ configuration:
         description: Controls whether new tasks can be created from the app.
         default_value: True
 
+    file_browser_tabs:
+        type: list
+        description: "Controls what tabs are visible in the main browser"
+        allows_empty: True
+        values:
+          type: str
+        default_value: ['All', 'Working', 'Publishes']
+
     # Save specific options
     #
 

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -225,7 +225,7 @@ class BrowserForm(QtGui.QWidget):
             if "All" in preferred_tabs:
                 self._add_file_list_form("All", "All Files", show_work_files=True, show_publishes=True)
             if "Working" in preferred_tabs:
-                self._add_file_list_form("Workingxxx", "Work Files", show_work_files=True, show_publishes=False)
+                self._add_file_list_form("Working", "Work Files", show_work_files=True, show_publishes=False)
             if "Publishes" in preferred_tabs:
                 self._add_file_list_form("Publishes", "Publishes", show_work_files=False, show_publishes=True)
 

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -221,9 +221,13 @@ class BrowserForm(QtGui.QWidget):
             self._file_model.set_users(self._file_filters.users)
 
             # add an 'all files' tab:
-            self._add_file_list_form("All", "All Files", show_work_files=True, show_publishes=True )
-            self._add_file_list_form("Working", "Work Files", show_work_files=True, show_publishes=False)
-            self._add_file_list_form("Publishes", "Publishes", show_work_files=False, show_publishes=True)
+            preferred_tabs = app.get_setting("file_browser_tabs")
+            if "All" in preferred_tabs:
+                self._add_file_list_form("All", "All Files", show_work_files=True, show_publishes=True)
+            if "Working" in preferred_tabs:
+                self._add_file_list_form("Workingxxx", "Work Files", show_work_files=True, show_publishes=False)
+            if "Publishes" in preferred_tabs:
+                self._add_file_list_form("Publishes", "Publishes", show_work_files=False, show_publishes=True)
 
     def _add_file_list_form(self, tab_name, search_label, show_work_files, show_publishes):
         """


### PR DESCRIPTION
This is an implementation of https://support.shotgunsoftware.com/hc/en-us/community/posts/360002740574-workfiles2-settings-for-main-panel-tabs

There were too many entries in the "All" tab for it to be a reasonable default. Most of the entries were publishes that did not need to be opened very often. Artists ended up getting confused by which file they should be opening