### PR TITLE
SG-6431 Fixes a bug with the new file action

### DIFF
--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -84,7 +84,7 @@ class FileAction(Action):
                 if template_keys <= ctx_keys:
                     # we've found the longest template that contains only context fields
                     break
-                ctx_template = template.parent
+                ctx_template = ctx_template.parent
                 
             if not ctx_template:
                 # couldn't figure out the path to test so assume that we need to create folders:


### PR DESCRIPTION
This now makes sure that the while loop properly recursively checks the parent templates, instead of potentially getting stuck in an endless loop. Previously if the statement `template_keys <= ctx_keys` wasn't immediately true, then it would continuously loop forever, causing the DCC to lock up.

This could be replicated by having a `version` folder in your workfiles template something like this:

```
max_asset_work:
        definition: '@asset_root/work/3dsmax/v{version}/{name}.v{version}.max'
```
