### PR TITLE
SG-4520: Fixes the "my tasks" checkbox in entity tree views.

### DIFF
--- a/python/tk_multi_workfiles/entity_tree/entity_tree_proxy_model.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_proxy_model.py
@@ -57,6 +57,13 @@ class EntityTreeProxyModel(EntityProxyModel):
             if not src_idx.isValid():
                 return False
 
+            # The only way we can traverse down to the Task level of the
+            # entity hierarchy and determine whether a Task is assigned to
+            # the current user is to load the child data up front for each
+            # index in the model. The downside to this is that it might be
+            # slow on some high-volume projects, but the upside is that the
+            # "My Tasks" checkbox in the entity tree view actually works.
+            src_idx.model().ensure_data_is_loaded(src_idx)
             item = src_idx.model().itemFromIndex(src_idx)
             sg_entity = src_idx.model().get_entity(item)
 


### PR DESCRIPTION
In order for the "My Tasks" checkbox to function properly, the entity tree data has to have been queried from Shotgun. Otherwise, there are no Task entities to check assignments on and we end up with an empty view even when there are Tasks assigned to the current user. 

**Symptoms:**

- Navigating to a tab with an entity tree view ("Shots" or "Assets" in the default configuration) and checking on the "My Tasks" checkbox resulted in an empty entity tree.
- If the user drilled down into the entity tree prior to checking on "My Tasks", thereby forcing the tree to be populated, the "My Tasks" checkbox would work properly for any Tasks that had already been drilled down to.

**Solution:**

When filtering for "My Tasks" behavior, we force child item data to be loaded for each index processed, which ensures we have all of the data from Shotgun about Tasks that we need to determine their assignments.

**Caveats:**

I assume this could be slow if there's a ton of entity data to load. However, I don't see any other way for it to work, so we probably have to live with it.