### PR TITLE
SG-4520: Hides the "my tasks" checkbox when using deferred queries.

### DIFF
--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -22,6 +22,7 @@ from .entity_tree_proxy_model import EntityTreeProxyModel
 from ..framework_qtwidgets import Breadcrumb, overlay_widget
 from ..util import get_model_str, map_to_source, get_source_model, monitor_qobject_lifetime
 from ..util import get_sg_entity_name_field
+from ..entity_models import ShotgunDeferredEntityModel
 
 
 class EntityTreeForm(QtGui.QWidget):
@@ -102,9 +103,12 @@ class EntityTreeForm(QtGui.QWidget):
         self._ui.search_ctrl.set_placeholder_text("Search %s" % search_label)
         self._ui.search_ctrl.setToolTip("Press enter to complete the search")
 
-        # enable/hide the my-tasks-only button if we are showing tasks:
+        # Hide the my-tasks-only checkbox if we are showing tasks, or if the entity
+        # model is making use of deferred queries. In the latter case, we don't
+        # have the data queried up front that's needed to properly filter the
+        # tree down to "my tasks", so the checkbox won't function properly.
         represents_tasks = entity_model.represents_tasks
-        if not represents_tasks:
+        if not represents_tasks or isinstance(entity_model, ShotgunDeferredEntityModel):
             self._ui.my_tasks_cb.hide()
 
         # enable/hide the new task button if we have tasks and task creation is allowed:


### PR DESCRIPTION
When deferred queries are used for an entity tree view, we don't have the data queried up front that's required to properly filter the tree. As a result, the behavior of the "my tasks" checkbox in those views is completely broken. Since we do not have a workaround that's performant, the solution is to hide that checkbox when deferred queries are being used.