### PR TITLE
Update context when a workfile is copied from one sandbox's user to a different one.

### DIFF
--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -196,6 +196,9 @@ class InteractiveOpenAction(OpenFileAction):
         src_path = None
         work_path = file.path
         
+        # the context that the workfile will be opened in
+        new_ctx = env.context
+
         # construct a context for this path to determine if it's in
         # a user sandbox or not:
         if env.context.user:
@@ -235,8 +238,11 @@ class InteractiveOpenAction(OpenFileAction):
 
                     src_path = work_path
                     work_path = local_path
+                    # resolve the new context from the work path as it is 
+                    # different from the previous user's sandbox context 
+                    new_ctx = env.context.sgtk.context_from_path(work_path)
 
-        return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
+        return self._do_copy_and_open(src_path, work_path, None, not file.editable, new_ctx, parent_ui)
 
     def _open_previous_publish(self, file, env, parent_ui):
         """


### PR DESCRIPTION
Update the context with the relevant user information when a workfile is copied from one sandbox's user to a different one. 
At the moment the context passed to the _do_copy_and_open function is the one from the original user. Therefore, when "File Save ..." option is used, the resolved workfile template contains the wrong username when saving a new version.
