### PR TITLE
For  SG-8929, workfile entity proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+.DS_Store
 
 # Installer logs
 pip-log.txt

--- a/app.py
+++ b/app.py
@@ -14,7 +14,6 @@ Provides File Open/Save functionality for Work Files
 """
 
 import os
-
 import sgtk
 
 
@@ -70,6 +69,10 @@ class MultiWorkFiles(sgtk.platform.Application):
                     }
                 }
             }
+        )
+
+        self.workfiles_management = self.create_hook_instance(
+            self.get_setting("workfiles_management")
         )
 
         # Process auto startup options - but only on certain supported platforms

--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         )
 
         self.workfiles_management = self.create_hook_instance(
-            self.get_setting("workfiles_management")
+            self.get_setting("hook_workfiles_management")
         )
 
         # Process auto startup options - but only on certain supported platforms

--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -236,7 +236,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
         elif context.entity:
             filters = [["sg_link", "is", context.entity]]
         else:
-            filters = [["entity", "is", context.project]]
+            filters = [["sg_link", "is", context.project]]
 
         filters.append(["sg_template", "is", work_template.name])
 

--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Abstract outs the discovery of files on disk.
+"""
+
+import os
+
+from sgtk import get_hook_baseclass
+
+
+class WorkfilesManagement(get_hook_baseclass()):
+
+    WORKFILE_ENTITY = "CustomEntity45"
+
+    def is_implemented(self):
+        return False
+
+    def _get_filter_from_context(self, context):
+
+        # Create a filter for the context. Do not bother creating a super complex filter.
+        # If task is set then every other field is implied.
+        if context.task:
+            filters = [["sg_step", "is", context.task]]
+        elif context.step:
+            filters = [
+                ["sg_link", "is", context.entity or context.project],
+                ["sg_step", "is", context.step]
+            ]
+        elif context.entity:
+            filters = [["sg_link", "is", context.entity]]
+        else:
+            filters = [["entity", "is", context.project]]
+
+        return filters
+
+    def register_workfiles(self, name, version, context, work_template, path, description, image):
+        self.parent.shotgun.create(
+            self.WORKFILE_ENTITY,
+            {
+                "code": name,
+                "sg_version": version,
+                "sg_task": context.task,
+                "sg_step": context.step,
+                "sg_link": context.entity or context.project,
+                "sg_work_template": work_template.name,
+                "sg_path": path,
+                "project": context.project
+            }
+        )
+
+    def find_work_files(self, context, work_template, version_compare_ignore_fields, valid_file_extensions):
+        work_files = self.parent.shotgun.find(
+            self.WORKFILE_ENTITY,
+            self._get_filter_from_context(context).extend(
+                ["sg_work_template", "is", work_template.name]
+            ),
+            [
+                "code", "description", "image",
+                "updated_at", "updated_by",
+                "sg_version", "sg_link", "sg_step", "sg_task",
+                "sg_path"
+            ]
+        )
+
+        work_file_item_details = []
+        for wf in work_files:
+            print(wf)
+            path = self.get_publish_path(wf["sg_path"])
+
+            # skip file if it doesn't contain a valid file extension:
+            if valid_file_extensions and os.path.splitext(path)[1] not in valid_file_extensions:
+                continue
+
+            work_file_item_details.append({
+                "path": path,
+                "version": wf["sg_version"],
+                "name": wf["code"],
+                "task": wf["sg_task"],
+                "description": wf["description"],
+                "thumbnail": wf["image"],
+                "modified_at": wf["updated_at"],
+                "modified_by": wf["updated_by"],
+            })
+
+        return work_file_item_details

--- a/info.yml
+++ b/info.yml
@@ -222,6 +222,16 @@ configuration:
           type: str
         default_value: ['All', 'Working', 'Publishes']
 
+    show_workfile_actions_on_publishes:
+        type: bool
+        description: Show workfile related operations on publishes.
+        default_value: true
+
+    show_publish_actions_on_workfiles:
+        type: bool
+        description: Show publish related operations on workfiles.
+        default_value: true
+
     # Save specific options
     #
 

--- a/info.yml
+++ b/info.yml
@@ -89,6 +89,11 @@ configuration:
         description: Specify a hook that will create the task and do any input validation that is
                      required.
 
+    hook_workfiles_management:
+        type: hook
+        default_Value: "{self}/workfiles_management.py"
+        description: Hook that allows to take over workfiles discovery and tracking.
+
     # General preferences
     #
     entities:

--- a/info.yml
+++ b/info.yml
@@ -158,7 +158,7 @@ configuration:
     show_my_tasks:
         type: bool
         description: Define if the My Tasks view should be visible or not.
-        default_value: False
+        default_value: True
         default_value_tk-hiero: False
 
     auto_expand_tree:

--- a/info.yml
+++ b/info.yml
@@ -91,7 +91,7 @@ configuration:
 
     hook_workfiles_management:
         type: hook
-        default_Value: "{self}/workfiles_management.py"
+        default_value: "{self}/workfiles_management.py"
         description: Hook that allows to take over workfiles discovery and tracking.
 
     # General preferences
@@ -158,7 +158,7 @@ configuration:
     show_my_tasks:
         type: bool
         description: Define if the My Tasks view should be visible or not.
-        default_value: True
+        default_value: False
         default_value_tk-hiero: False
 
     auto_expand_tree:

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -214,28 +214,16 @@ class InteractiveOpenAction(OpenFileAction):
                     ctx_fields = local_ctx.as_template_fields(env.work_template)
                     fields.update(ctx_fields)
                     if "version" in fields:
-                        # Check for existing Workfiles linked to the current context for the
-                        # new user to determine the version of the new user's Workfile.
-                        new_user_version = 1
-                        workfile_filters = [
-                            ["project", "is", local_ctx.project],
-                            ["sg_template", "is", env.work_template.name],
-                            ["sg_sandbox", "is", local_ctx.user],
-                        ]
-                        if local_ctx.entity:
-                            workfile_filters.append(["sg_link", "is", local_ctx.entity])
-                        if local_ctx.step:
-                            workfile_filters.append(["sg_step", "is", local_ctx.step])
-                        if local_ctx.task:
-                            workfile_filters.append(["sg_task", "is", local_ctx.task])
-                        new_user_workfiles = self._app.shotgun.find(
-                            self._app.workfiles_management.WORKFILE_ENTITY,
-                            workfile_filters,
-                            ["sg_version"],
-                            order=[{"field_name": "sg_version", "direction": "desc"}]
-                        )
-                        if new_user_workfiles:
-                            fields["version"] = (new_user_workfiles[0].get("sg_version") or 0) + 1
+                        try:
+                            fields["version"] = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
+                                # Name is not mandatory
+                                fields.get("name"),
+                                local_ctx,
+                                env.work_template
+                            )
+                        except NotImplementedError:
+                            # We keep the default value.
+                            pass
 
                     # construct the local path from these fields:
                     local_path = env.work_template.apply_fields(fields)
@@ -268,13 +256,13 @@ class InteractiveOpenAction(OpenFileAction):
             # create the corresponding Workfile entity.
             workfile_fields = env.work_template.get_fields(work_path)
             self._app.workfiles_management.register_workfile(
-                name=file.name,
-                version=(workfile_fields.get("version") or 0),
-                context=workfile_context,
-                work_template=env.work_template,
-                path=work_path,
-                description=file.workfile_description,
-                image=file.thumbnail
+                file.name,
+                (workfile_fields.get("version") or 0),
+                workfile_context,
+                env.work_template,
+                work_path,
+                file.workfile_description,
+                file.thumbnail
             )
 
         return file_copied

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -240,13 +240,18 @@ class CopyAndOpenInCurrentWorkAreaAction(OpenFileAction):
 class ContinueFromFileAction(OpenFileAction):
     """
     """
-    def __init__(self, label, file, file_versions, environment):
+    def __init__(self, label, file, file_versions, environment, next_version=None):
         """
         """
-        # Q. should the next version include the current version?
-        all_versions = [v for v, f in file_versions.iteritems()] + [file.version]
-        max_version = max(all_versions)
-        self._version = max_version+1
+
+        if next_version is not None:
+            self._version = next_version
+        else:
+            # Q. should the next version include the current version?
+            all_versions = v.keys() + [file.version]
+            max_version = max(all_versions)
+            self._version = max_version + 1
+
         label = "%s (as v%03d)" % (label, self._version) 
         OpenFileAction.__init__(self, label, file, file_versions, environment)
     

--- a/python/tk_multi_workfiles/actions/open_publish_actions.py
+++ b/python/tk_multi_workfiles/actions/open_publish_actions.py
@@ -54,6 +54,9 @@ class ContinueFromPublishAction(ContinueFromFileAction):
     def __init__(self, file, file_versions, environment):
         """
         """
+        # This command does not pass down a next_version because it is assumed
+        # that the publishes have all been retrieved from Shotgun, so therefore
+        # the default behaviour from the base class of doing max + 1 works great.
         ContinueFromFileAction.__init__(self, "Continue Working From Publish", file, file_versions, environment)
 
     def execute(self, parent_ui):

--- a/python/tk_multi_workfiles/actions/open_publish_actions.py
+++ b/python/tk_multi_workfiles/actions/open_publish_actions.py
@@ -51,13 +51,13 @@ class OpenPublishAction(OpenFileAction):
 class ContinueFromPublishAction(ContinueFromFileAction):
     """
     """
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, file, file_versions, environment, next_version_override):
         """
         """
         # This command does not pass down a next_version because it is assumed
         # that the publishes have all been retrieved from Shotgun, so therefore
         # the default behaviour from the base class of doing max + 1 works great.
-        ContinueFromFileAction.__init__(self, "Continue Working From Publish", file, file_versions, environment)
+        ContinueFromFileAction.__init__(self, "Continue working from Publish in your Work Area", file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """
@@ -74,8 +74,8 @@ class ContinueFromPublishAction(ContinueFromFileAction):
 class CopyAndOpenPublishInCurrentWorkAreaAction(CopyAndOpenInCurrentWorkAreaAction):
     """
     """
-    def __init__(self, file, file_versions, environment):
-        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open Publish in Current Work Area...", file, file_versions, environment)
+    def __init__(self, file, file_versions, environment, next_version_override):
+        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open Publish in Current Work Area...", file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -75,7 +75,20 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
         else:
             label = "Continue Working"
 
-        ContinueFromFileAction.__init__(self, label, file, file_versions, environment)
+        # Figure out what could be the default next version number.
+        try:
+            next_version = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
+                # Name is not mandatory
+                environment.work_template.get_fields(file.path).get("name"),
+                environment.context,
+                environment.work_template
+            )
+        except NotImplementedError:
+            next_version = None
+
+        ContinueFromFileAction.__init__(
+            self, label, file, file_versions, environment, next_version
+        )
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -63,32 +63,24 @@ class OpenWorkfileAction(OpenFileAction):
 class ContinueFromWorkFileAction(ContinueFromFileAction):
     """
     """
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, file, file_versions, environment, next_version_override):
         """
+        :param FileItem file: File the menu item is launched from.
+        :param file_versions: All the file versions, publishes and workfiles, associated with the selection.
+        :param environment: Environment associated with this file.
+        :param int next_version_override: Allows to override the next version for the current version
+            stream of this file.
         """
         label = ""
         if (environment and environment.contains_user_sandboxes
             and environment.context and environment.context.user and g_user_cache.current_user
             and environment.context.user["id"] != g_user_cache.current_user["id"]):
             sandbox_user = environment.context.user.get("name", "Unknown").split(" ")[0]
-            label = "Continue Working from %s's File" % sandbox_user
+            label = "Continue Working from %s's Work File in your Work Area" % sandbox_user
         else:
             label = "Continue Working"
 
-        # Figure out what could be the default next version number.
-        try:
-            next_version = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
-                # Name is not mandatory
-                environment.work_template.get_fields(file.path).get("name"),
-                environment.context,
-                environment.work_template
-            )
-        except NotImplementedError:
-            next_version = None
-
-        ContinueFromFileAction.__init__(
-            self, label, file, file_versions, environment, next_version
-        )
+        ContinueFromFileAction.__init__(self, label, file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """
@@ -107,10 +99,10 @@ class CopyAndOpenFileInCurrentWorkAreaAction(CopyAndOpenInCurrentWorkAreaAction)
     Action that copies a file to the current work area as the next available version
     and opens it from there
     """
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, file, file_versions, environment, next_version_override):
         """
         """
-        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open in Current Work Area...", file, file_versions, environment)
+        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open in Current Work Area...", file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -12,6 +12,7 @@
 """
 import os
 from sgtk.platform.qt import QtCore, QtGui
+import sgtk
 
 from .file_action import FileAction
 from ..scene_operation import save_file, SAVE_FILE_AS_ACTION
@@ -28,7 +29,7 @@ class SaveAsFileAction(FileAction):
         """
         """
         if (not self.file or not self.file.path 
-            or not self.environment or not self.environment.context):
+        or not self.environment or not self.environment.context):
             return False
 
         # switch context:
@@ -47,6 +48,9 @@ class SaveAsFileAction(FileAction):
         # and save the current file as the new path:
         try:
             save_file(self._app, SAVE_FILE_AS_ACTION, self.environment.context, self.file.path)
+            sgtk.platform.current_bundle().workfiles_management.register_workfile(
+                self.environment.context, self.environment.context, self.file.path
+            )
         except Exception, e:
             QtGui.QMessageBox.critical(None, "Failed to save file!", "Failed to save file:\n\n%s" % e)
             self._app.log_exception("Failed to save file!")

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -29,7 +29,7 @@ class SaveAsFileAction(FileAction):
         """
         """
         if (not self.file or not self.file.path 
-        or not self.environment or not self.environment.context):
+            or not self.environment or not self.environment.context):
             return False
 
         # switch context:
@@ -48,9 +48,12 @@ class SaveAsFileAction(FileAction):
         # and save the current file as the new path:
         try:
             save_file(self._app, SAVE_FILE_AS_ACTION, self.environment.context, self.file.path)
-            sgtk.platform.current_bundle().workfiles_management.register_workfile(
-                self.environment.context, self.environment.context, self.file.path
-            )
+            if sgtk.platform.current_bundle().workfiles_management.is_implemented():
+                sgtk.platform.current_bundle().workfiles_management.register_workfile(
+                    self.file.name, self.file.version,
+                    self.environment.context, self.environment.work_template, self.file.path,
+                    self.file.workfile_description, self.file.thumbnail
+                )
         except Exception, e:
             QtGui.QMessageBox.critical(None, "Failed to save file!", "Failed to save file:\n\n%s" % e)
             self._app.log_exception("Failed to save file!")

--- a/python/tk_multi_workfiles/actions/save_as_file_action.py
+++ b/python/tk_multi_workfiles/actions/save_as_file_action.py
@@ -48,12 +48,14 @@ class SaveAsFileAction(FileAction):
         # and save the current file as the new path:
         try:
             save_file(self._app, SAVE_FILE_AS_ACTION, self.environment.context, self.file.path)
-            if sgtk.platform.current_bundle().workfiles_management.is_implemented():
+            try:
                 sgtk.platform.current_bundle().workfiles_management.register_workfile(
                     self.file.name, self.file.version,
                     self.environment.context, self.environment.work_template, self.file.path,
                     self.file.workfile_description, self.file.thumbnail
                 )
+            except NotImplementedError:
+                pass
         except Exception, e:
             QtGui.QMessageBox.critical(None, "Failed to save file!", "Failed to save file:\n\n%s" % e)
             self._app.log_exception("Failed to save file!")

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -731,6 +731,9 @@ class AsyncFileFinder(FileFinder):
             search.user_work_areas[user_id] = user_work_area
 
             if self._app.workfiles_management.is_implemented():
+                # find and filter work files. The hook does these two steps in a single call.
+                # we could arguably break it into two tasks, but I'm not sure
+                # what benefit there would be. The filtering is 100% processing only and no file io.
                 previous_work_file_task = self._bg_task_manager.add_task(
                     self._task_find_and_filter_work_files,
                     group=search.id,
@@ -1014,6 +1017,10 @@ class AsyncFileFinder(FileFinder):
 
     def _task_find_and_filter_work_files(self, environment, **kwargs):
         """
+        Background task that finds and filters available work files.
+
+        :param environment: Environment for which we'll want to scan for files.
+        :type environment: :class:`tk_multi_workfiles2.Environment`
         """
         work_files = []
         if (environment and environment.context and environment.work_template):

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -169,8 +169,7 @@ class FileFinder(QtCore.QObject):
         # Find and process all work files
         filted_work_files = self._find_and_filter_work_files(
             context, work_template,
-            version_compare_ignore_fields, valid_file_extensions,
-            name_map, filter_file_key
+            version_compare_ignore_fields, valid_file_extensions
         )
         work_file_item_details = self._process_work_files(
             filted_work_files,
@@ -214,8 +213,7 @@ class FileFinder(QtCore.QObject):
     def _find_and_filter_work_files(
         self,
         context, work_template,
-        version_compare_ignore_fields, valid_file_extensions,
-        name_map, filter_file_key
+        version_compare_ignore_fields, valid_file_extensions
     ):
         if self._app.workfiles_management.is_implemented():
             return self._app.workfiles_management.find_work_files(
@@ -1020,12 +1018,11 @@ class AsyncFileFinder(FileFinder):
         work_files = []
         if (environment and environment.context and environment.work_template):
             work_files = self._find_and_filter_work_files(
-                environment.context,
-                environment.work_template,
-                environment.version_compare_ignore_fields
+                environment.context, environment.work_template,
+                environment.version_compare_ignore_fields,
+                environment.valid_file_extensions
             )
         return {"work_files": work_files}
-
 
     def _task_filter_work_files(self, work_files, environment, **kwargs):
         """

--- a/python/tk_multi_workfiles/file_item.py
+++ b/python/tk_multi_workfiles/file_item.py
@@ -259,6 +259,10 @@ class FileItem(object):
         """
         return self._details.get("editable_reason") or ""
 
+    @property
+    def workfile_description(self):
+        return self._details.get("description") or ""
+
     # ------------------------------------------------------------------------------------------
     # Published file properties
 

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -752,7 +752,8 @@ class FileSaveForm(FileFormBase):
             return
 
         # construct a temporary file item:
-        file_item = FileItem(key=None, is_work_file=True, work_path=path_to_save)
+        # FIXME: This needs to be filled with comments and thumbnail as well.
+        file_item = FileItem(key=None, is_work_file=True, work_path=path_to_save, work_details={"version": version})
 
         # Build and execute the save action:
         action = SaveAsFileAction(file_item, self._current_env)

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -367,28 +367,37 @@ class FileSaveForm(FileFormBase):
         next_version = None
         version_is_used = "version" in env.work_template.keys
         if version_is_used:
-            # version is used so we need to find the latest version - this means 
-            # searching for files...
-            # need a file key to find all versions so lets build it:
-            file_key = FileItem.build_file_key(fields, env.work_template, 
-                                               env.version_compare_ignore_fields)
-            file_versions = None
-            if self._file_model:
-                file_versions = self._file_model.get_cached_file_versions(file_key, env, clean_only=True)
-            if file_versions == None:
-                # fall back to finding the files manually - this will be slower!  
-                try:
-                    finder = FileFinder()
-                    files = finder.find_files(env.work_template, 
-                                              env.publish_template, 
-                                              env.context,
-                                              file_key) or []
-                except TankError, e:
-                    raise TankError("Failed to find files for this work area: %s" % e)
-                file_versions = [f.version for f in files]
 
-            max_version = max(file_versions or [0])
-            next_version = max_version + 1
+            try:
+                next_version = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
+                    # Name is not mandatory
+                    fields.get("name"),
+                    env.context,
+                    env.work_template
+                )
+            except NotImplementedError:
+                # version is used so we need to find the latest version - this means
+                # searching for files...
+                # need a file key to find all versions so lets build it:
+                file_key = FileItem.build_file_key(fields, env.work_template,
+                                                   env.version_compare_ignore_fields)
+                file_versions = None
+                if self._file_model:
+                    file_versions = self._file_model.get_cached_file_versions(file_key, env, clean_only=True)
+                if file_versions is None:
+                    # fall back to finding the files manually - this will be slower!
+                    try:
+                        finder = FileFinder()
+                        files = finder.find_files(env.work_template,
+                                                  env.publish_template,
+                                                  env.context,
+                                                  file_key) or []
+                    except TankError, e:
+                        raise TankError("Failed to find files for this work area: %s" % e)
+                    file_versions = [f.version for f in files]
+
+                max_version = max(file_versions or [0])
+                next_version = max_version + 1
 
             # update version:
             version = next_version if use_next_version else max(version, next_version)

--- a/python/tk_multi_workfiles/user_cache.py
+++ b/python/tk_multi_workfiles/user_cache.py
@@ -41,15 +41,6 @@ class UserCache(Threaded):
         """
         return self._current_user
 
-    def get_user_details_for_id(self, user_id):
-        """
-        Get the user details for the specified user entity id.
-
-        :param user_id: The entity id of the user whose details should be returned
-        :returns:       A Shotgun entity dictionary for the user if found, otherwise {}
-        """
-        return self.get_user_details_for_ids([user_id]).get(id)
-
     def get_user_details_for_ids(self, ids):
         """
         Get the user details for all users represented by the list of supplied entity ids

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -406,13 +406,11 @@ class WorkArea(object):
             # already resolved users!
             return users
 
-        # update cache:
-
-        if sgtk.platform.current_bundle().workfiles_management.is_implemented():
+        try:
             user_list = sgtk.platform.current_bundle().workfiles_management.resolve_user_sandboxes(
-                self.context, template
+                self.context, template, is_work_template
             )
-        else:
+        except NotImplementedError:
             user_list = self._resolve_user_sandboxes_from_files(template)
 
         # look these up in the user cache:


### PR DESCRIPTION
This change allows to write a hook that allows to take over file discovery so that non-published file information can be tracked in Shotgun instead of being discovered on disk. In order to achieve this, a [custom entity](https://github.com/shotgunsoftware/tk-multi-workfiles2/blob/SG-8929_workfile_entity_proof_of_concept/hooks/workfiles_management.py#L22-L29) and a [new hook](https://github.com/shotgunsoftware/tk-multi-workfiles2/blob/SG-8929_workfile_entity_proof_of_concept/hooks/workfiles_management.py) were introduced.

The three methods that need to be implemented are:

`register_workfile`: This is invoked on file save and is used to update Shotgun with the workfile information.

`find_work_files`: This is invoked during file load and is used to get information for a given context and template.

`resolver_user_sandbox`: This is invoked to populate the user button when the template uses user sandboxing.

Unfortunately, this proof of concept doesn't feel really faster, it might actually even be a bit slower than the file based version since the round trip to Shotgun is probably slower than the round trip to disk.