### PR TITLE
Create Workfiles for additional workflows

### DIFF
--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -236,7 +236,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
         elif context.entity:
             filters = [["sg_link", "is", context.entity]]
         else:
-            filters = [["entity", "is", context.project]]
+            filters = [["sg_link", "is", context.project]]
 
         filters.append(["sg_template", "is", work_template.name])
 


### PR DESCRIPTION
Create Workfile entities for the following workflows:
   - Workfile that gets created when a Published file is opened through the dialog
   - Workfile that gets created when a Person copies another Person's workfile into their own sandbox 

Use the 'sg_link' field (instead of 'entity') for Workfiles implemented as custom entities