### PR TITLE
Replaced toTuple for PyQt compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,9 +149,10 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         Color used to display errors in the UI.
 
-        :returns: An RGBA tuple.
+        :returns: An RGBA tuple of int (0-255).
         """
-        return sgtk.platform.qt.QtGui.QColor(self.style_constants["SG_ALERT_COLOR"]).toTuple()
+        color = sgtk.platform.qt.QtGui.QColor(self.style_constants["SG_ALERT_COLOR"])
+        return color.red(), color.green(), color.blue(), color.alpha()
 
 
 class DebugWrapperShotgun(object):


### PR DESCRIPTION
Discovered while trying to integrate `tk-katana`.

See [PyQt API docs](http://pyqt.sourceforge.net/Docs/PyQt4/qcolor.html) compared to [PySide API docs](https://srinikom.github.io/pyside-docs/PySide/QtGui/QColor.html#PySide.QtGui.PySide.QtGui.QColor.toTuple) for QColor