### PR TITLE
Added __ignore *args

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,13 +103,13 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         self.log_debug("Destroying tk-multi-workfiles2")
 
-    def show_file_open_dlg(self):
+    def show_file_open_dlg(self, *__ignore):
         """
         Launch the main File Open UI
         """
         self._tk_multi_workfiles.WorkFiles.show_file_open_dlg()
 
-    def show_file_save_dlg(self):
+    def show_file_save_dlg(self, *__ignore):
         """
         Launch the main File Save UI
         """


### PR DESCRIPTION
Discovered while trying to integrate `tk-katana`.

Due to signals/slots, Qt was passing in extra args to `show_file_open_dlg()` and `show_file_save_dlg()` when the menu actions are triggered, resulting in Python complaining about extra args given when only `self` is expected.