### PR TITLE
For SG-10271, unique version number across sandboxes

### DIFF
--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -31,7 +31,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
     WORKFILE_ENTITY = "CustomEntity45"
     # The custom entity has the following custom fields:
     # sg_version (number): version number of the scene
-    # sg_name_field (text): user specified name at save time
+    # sg_name_field (text): user specified name at save time.
     # sg_task (task entity): task associated with the work file
     # sg_step (step entity): step associated with the work file
     # sg_link (asset, project or shot entity): entity associated with the work file
@@ -42,12 +42,17 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
     # sg_path_cache_storage (local storage entity): LocalStorage the file is part of. This can't
     #   be created through the GUI, but can be programmatically:
     #   shotgun.schema_field_create("CustomEntity45", "entity", "Path Cache Storage", {"valid_types": ["LocalStorage"]})
+    #
+    # Note that the code field in Shotgun will be the name of the file on disk.
+    # The sg_name_field value however is the value of the {name} token inside the file name,
+    # e.g. given the template {name}.v{version}.ma and the file name (code) of car.v003.ma,
+    # sg_name_field would be set to "car".
 
     def register_workfile(self, name, version, context, work_template, path, description, image):
         """
         Register a work file with Shotgun.
 
-        :param name str: Name of the work file.
+        :param name str: File name on disk of the work file. Not to be confused with the {name} token.
         :param int version: Version of the work file.
         :param context: Context we're saving into.
         :type context: :class:`sgtk.Context`
@@ -86,10 +91,13 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
             "sg_path": sg_path,
             "project": context.project
         }
+        # Extract the name token outside of the path, so it can be used for filtering when
+        # searching for files.
         if "name" in work_template.keys:
             new_workfile["sg_name_field"] = work_template.get_fields(path)["name"]
         else:
             new_workfile["sg_name_field"] = None
+
         if self._is_using_sandboxes(work_template):
             new_workfile["sg_sandbox"] = context.user
 

--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -103,14 +103,25 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
         )
 
     def get_next_workfile_version(self, name, context, work_template):
+        """
+        Compute the next version for a workfile.
 
+        :param str name: User specified name. Can be ``None``.
+        :param context: Context for the files.
+        :type context: :class:`sgtk.Context`
+        :param work_template: Template for which we want to compute the next version.
+        :type work_template: :class:`sgtk.Template`
+
+        :returns: An integer indicating the next available and unique version number.
+        """
         # TODO: This could probably be optimized by a summarize call for the maximum
-        # value for the field version.
+        # value for the version field, but doing it this way ensures consistency of how
+        # workfiles are resolved.
         results = self._find_workfile_entities(
             context,
             work_template,
             ["sg_version"],
-            # We want unique version number per user.
+            # We want a unique version number per scene file.
             filter_by_user=False,
             name_filter=name
         )
@@ -248,6 +259,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
         :type work_template: :class:`sgtk.Template`
         :param list(str) fields: List of fields that should be retrieved.
         :param bool filter_by_user: If ``True``, only workfiles in user's sandbox will be returned.
+        :param name name_filter: If set, only workfiles with the given name will be returned.
         """
         # Build out a filter to return the requested files.
         if context.task:

--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -21,11 +21,15 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
     This hooks allows to drive file discovery and file persistence with the workfiles application.
 
     You need to implement at minimum the following hooks to get the basic functionality working:
-        - register_workfiles
+        - register_workfile
         - find_work_files
 
     If you intend on using user sandboxes for your workfiles, you can also implement
     `resolve_sandbox_users` to speed up sandbox discovery for a given context.
+
+    You can also tweak the next version computation logic in `get_next_workfile_version`. The default
+    behavior of the app is to use the next available number for a given the name supplied by the user,
+    template and context the file is saved into.
     """
 
     WORKFILE_ENTITY = "CustomEntity45"
@@ -48,11 +52,11 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
     # e.g. given the template {name}.v{version}.ma and the file name (code) of car.v003.ma,
     # sg_name_field would be set to "car".
 
-    def register_workfile(self, name, version, context, work_template, path, description, image):
+    def register_workfile(self, filename, version, context, work_template, path, description, image):
         """
         Register a work file with Shotgun.
 
-        :param name str: File name on disk of the work file. Not to be confused with the {name} token.
+        :param filename str: File name on disk of the work file. Not to be confused with the {name} token.
         :param int version: Version of the work file.
         :param context: Context we're saving into.
         :type context: :class:`sgtk.Context`
@@ -70,7 +74,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
             context.sgtk,
             context,
             path,
-            name,
+            filename,
             version,
             None,
             comment="",
@@ -82,7 +86,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
         )["path"]
 
         new_workfile = {
-            "code": name,
+            "code": filename,
             "sg_version": version,
             "sg_task": context.task,
             "sg_step": context.step,

--- a/hooks/workfiles_management.py
+++ b/hooks/workfiles_management.py
@@ -31,6 +31,7 @@ class WorkfilesManagement(sgtk.get_hook_baseclass()):
     WORKFILE_ENTITY = "CustomEntity45"
     # The custom entity has the following custom fields:
     # sg_version (number): version number of the scene
+    # sg_name_field (text): user specified name at save time
     # sg_task (task entity): task associated with the work file
     # sg_step (step entity): step associated with the work file
     # sg_link (asset, project or shot entity): entity associated with the work file

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -222,28 +222,8 @@ class InteractiveOpenAction(OpenFileAction):
                                 env.work_template
                             )
                         except NotImplementedError:
-                            # Check for existing Workfiles linked to the current context for the
-                            # new user to determine the version of the new user's Workfile.
-                            new_user_version = 1
-                            workfile_filters = [
-                                ["project", "is", local_ctx.project],
-                                ["sg_template", "is", env.work_template.name],
-                                ["sg_sandbox", "is", local_ctx.user],
-                            ]
-                            if local_ctx.entity:
-                                workfile_filters.append(["sg_link", "is", local_ctx.entity])
-                            if local_ctx.step:
-                                workfile_filters.append(["sg_step", "is", local_ctx.step])
-                            if local_ctx.task:
-                                workfile_filters.append(["sg_task", "is", local_ctx.task])
-                            new_user_workfiles = self._app.shotgun.find(
-                                self._app.workfiles_management.WORKFILE_ENTITY,
-                                workfile_filters,
-                                ["sg_version"],
-                                order=[{"field_name": "sg_version", "direction": "desc"}]
-                            )
-                            if new_user_workfiles:
-                                fields["version"] = (new_user_workfiles[0].get("sg_version") or 0) + 1
+                            # We keep the default value.
+                            pass
 
                     # construct the local path from these fields:
                     local_path = env.work_template.apply_fields(fields)

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -215,9 +215,9 @@ class InteractiveOpenAction(OpenFileAction):
                     fields.update(ctx_fields)
                     if "version" in fields:
                         try:
-                            name = fields.get("name")
                             fields["version"] = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
-                                name,
+                                # Name is not mandatory
+                                fields.get("name"),
                                 local_ctx,
                                 env.work_template
                             )

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -256,13 +256,13 @@ class InteractiveOpenAction(OpenFileAction):
             # create the corresponding Workfile entity.
             workfile_fields = env.work_template.get_fields(work_path)
             self._app.workfiles_management.register_workfile(
-                name=file.name,
-                version=(workfile_fields.get("version") or 0),
-                context=workfile_context,
-                work_template=env.work_template,
-                path=work_path,
-                description=file.workfile_description,
-                image=file.thumbnail
+                file.name,
+                (workfile_fields.get("version") or 0),
+                workfile_context,
+                env.work_template,
+                work_path,
+                file.workfile_description,
+                file.thumbnail
             )
 
         return file_copied

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -240,13 +240,18 @@ class CopyAndOpenInCurrentWorkAreaAction(OpenFileAction):
 class ContinueFromFileAction(OpenFileAction):
     """
     """
-    def __init__(self, label, file, file_versions, environment):
+    def __init__(self, label, file, file_versions, environment, next_version=None):
         """
         """
-        # Q. should the next version include the current version?
-        all_versions = [v for v, f in file_versions.iteritems()] + [file.version]
-        max_version = max(all_versions)
-        self._version = max_version+1
+
+        if next_version is not None:
+            self._version = next_version
+        else:
+            # Q. should the next version include the current version?
+            all_versions = [v for v, f in file_versions.iteritems()] + [file.version]
+            max_version = max(all_versions)
+            self._version = max_version + 1
+
         label = "%s (as v%03d)" % (label, self._version) 
         OpenFileAction.__init__(self, label, file, file_versions, environment)
     

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -248,7 +248,7 @@ class ContinueFromFileAction(OpenFileAction):
             self._version = next_version
         else:
             # Q. should the next version include the current version?
-            all_versions = [v for v, f in file_versions.iteritems()] + [file.version]
+            all_versions = v.keys() + [file.version]
             max_version = max(all_versions)
             self._version = max_version + 1
 

--- a/python/tk_multi_workfiles/actions/open_publish_actions.py
+++ b/python/tk_multi_workfiles/actions/open_publish_actions.py
@@ -54,6 +54,9 @@ class ContinueFromPublishAction(ContinueFromFileAction):
     def __init__(self, file, file_versions, environment):
         """
         """
+        # This command does not pass down a next_version because it is assumed
+        # that the publishes have all been retrieved from Shotgun, so therefore
+        # the default behaviour from the base class of doing max + 1 works great.
         ContinueFromFileAction.__init__(self, "Continue Working From Publish", file, file_versions, environment)
 
     def execute(self, parent_ui):

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -75,7 +75,23 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
         else:
             label = "Continue Working"
 
-        ContinueFromFileAction.__init__(self, label, file, file_versions, environment)
+        # Figure out what could be the default next version number.
+        if "name" in environment.work_template.keys:
+            name = environment.work_template.get_fields(file.path)["name"]
+        else:
+            name = None
+        try:
+            next_version = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
+                name,
+                environment.context,
+                environment.work_template
+            ) + 1
+        except NotImplementedError:
+            next_version = None
+
+        ContinueFromFileAction.__init__(
+            self, label, file, file_versions, environment, next_version
+        )
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -76,16 +76,13 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
             label = "Continue Working"
 
         # Figure out what could be the default next version number.
-        if "name" in environment.work_template.keys:
-            name = environment.work_template.get_fields(file.path)["name"]
-        else:
-            name = None
         try:
             next_version = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
-                name,
+                # Name is not mandatory
+                environment.work_template.get_fields(file.path).get("name"),
                 environment.context,
                 environment.work_template
-            ) + 1
+            )
         except NotImplementedError:
             next_version = None
 

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -384,7 +384,7 @@ class FileSaveForm(FileFormBase):
                 file_versions = None
                 if self._file_model:
                     file_versions = self._file_model.get_cached_file_versions(file_key, env, clean_only=True)
-                if file_versions == None:
+                if file_versions is None:
                     # fall back to finding the files manually - this will be slower!
                     try:
                         finder = FileFinder()


### PR DESCRIPTION
Takes Amy's fix for sandboxes and generalizes it so any time a workfile is saved a unique version number is generated across sandboxes.

This required a new field to be introduced on the `Workfile` custom entity: `sg_name_field`. This is the value of the name field in the save dialog. I didn't go with simply `sg_name` because I was afraid it would cause confusion between `code`, `name` and `sg_name`.

When moving to this new version of the app, the Workfile entity first need to be migrated to populate that field.

It could be (I haven't actually executed this) as simple as

```
for entity in sg.find("CustomEntity45", []):
    # Create a fake publish payload so we can ask core to resolve its path like we do
    # in the workfiles management app.
    fake_sg_publish_data = {
            "id": entity["id"],
            "path": entity["sg_path"]
    }
    sgtk.util.resolve_publish_path(sgtk, fake_sg_publish_data);
    sg.update(
        entity['type'], entity['id']
        {'sg_name_field': template.get_fields()["name"]}
   )
```
which will go through every single workfile, extract the name from the path field and push back that name to shotgun.