### PR TITLE
SG-10466: Minor change for PyQt5 compatibility.

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,9 +149,10 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         Color used to display errors in the UI.
 
-        :returns: An RGBA tuple.
+        :returns: An RGBA tuple of int (0-255).
         """
-        return sgtk.platform.qt.QtGui.QColor(self.style_constants["SG_ALERT_COLOR"]).toTuple()
+        color = sgtk.platform.qt.QtGui.QColor(self.style_constants["SG_ALERT_COLOR"])
+        return color.red(), color.green(), color.blue(), color.alpha()
 
 
 class DebugWrapperShotgun(object):


### PR DESCRIPTION
This is the change made in #67. We're simply removing use of the `toTuple` method provided by PySide in favor of an approach that will also work with PyQt5.