### PR TITLE
For SG-10961, small fixes for workfiles management

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -222,6 +222,16 @@ configuration:
           type: str
         default_value: ['All', 'Working', 'Publishes']
 
+    show_workfile_actions_on_publishes:
+        type: bool
+        description: Show workfile related operations on publishes.
+        default_value: true
+
+    show_publish_actions_on_workfiles:
+        type: bool
+        description: Show publish related operations on workfiles.
+        default_value: true
+
     # Save specific options
     #
 

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -219,6 +219,7 @@ class FileActionFactory(object):
         :returns: List of actions.
         """
         actions = []
+
         if not file_item.is_published:
             return actions
 

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -62,6 +62,9 @@ class FileActionFactory(object):
 
         app = sgtk.platform.current_bundle()
 
+        self._show_workfile_actions_on_publishes = app.get_setting("show_workfile_actions_on_publishes")
+        self._show_publish_actions_on_workfiles = app.get_setting("show_publish_actions_on_workfiles")
+
         # determine if this file is in a different users sandbox:
         self._in_other_users_sandbox = (
             work_area.contains_user_sandboxes

--- a/python/tk_multi_workfiles/actions/file_action_factory.py
+++ b/python/tk_multi_workfiles/actions/file_action_factory.py
@@ -119,16 +119,29 @@ class FileActionFactory(object):
             self._show_workfile_actions = True
             self._show_publish_actions = True
         else:
-            # If they are not, then we'll defer to the show_*_actions_on_* setting.
+            # If we're only showing one type of item, we'll go with
+            # what is in the selection.
+            # If the item is a workfile, we definitely want to show workfiles actions.
+            # If the item is a publish, but the publish actions on workfiles setting
+            # is turned on, we also want to show workfiles.
+            # If not, we won't show them.
             self._show_workfile_actions = file_item.is_local or (
                 file_item.is_published and show_workfile_actions_on_publishes
             )
+            # Similar logic, but for publish actions.
             self._show_publish_actions = file_item.is_published or (
                 file_item.is_local and show_publish_actions_on_workfiles
             )
 
         current_user_file_versions = self._get_current_user_file_versions(file_item)
 
+        # Each actions has their own way of computing the next version.
+        # For the workfiles management workflow however, there is only
+        # one way to grab the next available ticket for a workfile so
+        # we'll make sure that we grab it the right way. Because of this,
+        # we'll compute the value once here if the hook can compute
+        # the next version number and we'll pass it down as an override to all
+        # the actions that generate new files on disk.
         try:
             self._next_version_override = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
                 # Name is not mandatory

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -199,7 +199,6 @@ class InteractiveOpenAction(OpenFileAction):
         current_user = g_user_cache.current_user
         copy_to_new_user = (current_user and current_user["id"] != env.context.user["id"])
 
-
         # get fields from work path:
         fields = env.work_template.get_fields(work_path)
 
@@ -243,7 +242,7 @@ class InteractiveOpenAction(OpenFileAction):
                     workfile_context = local_ctx
 
         return self._do_copy_and_open(src_path, work_path, fields.get("version"), not file.editable,
-                                             env.context, parent_ui)
+                                      env.context, parent_ui)
 
     def _open_previous_publish(self, file, env, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -249,23 +249,8 @@ class InteractiveOpenAction(OpenFileAction):
                     work_path = local_path
                     workfile_context = local_ctx
 
-        file_copied = self._do_copy_and_open(src_path, work_path, None, not file.editable,
+        return self._do_copy_and_open(src_path, work_path, None, not file.editable,
                                              env.context, parent_ui)
-        if file_copied and copy_to_new_user:
-            # If a user is copying another user's Workfile into their sandbox,
-            # create the corresponding Workfile entity.
-            workfile_fields = env.work_template.get_fields(work_path)
-            self._app.workfiles_management.register_workfile(
-                file.name,
-                (workfile_fields.get("version") or 0),
-                workfile_context,
-                env.work_template,
-                work_path,
-                file.workfile_description,
-                file.thumbnail
-            )
-
-        return file_copied
 
     def _open_previous_publish(self, file, env, parent_ui):
         """
@@ -357,13 +342,4 @@ class InteractiveOpenAction(OpenFileAction):
                 self._app.log_exception("Failed to resolve work file path from publish path: %s" % src_path)
                 return False
 
-        file_copied = self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
-        if file_copied:
-            # Create a corresponding Workfile entity if the app is setup to do that.
-            self._app.workfiles_management.register_workfile(
-                file.name, new_version, env.context, env.work_template, work_path,
-                file.workfile_description, file.thumbnail
-            )
-
-        return file_copied
-
+        return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -198,7 +198,11 @@ class InteractiveOpenAction(OpenFileAction):
         workfile_context = env.context
         current_user = g_user_cache.current_user
         copy_to_new_user = (current_user and current_user["id"] != env.context.user["id"])
-        
+
+
+        # get fields from work path:
+        fields = env.work_template.get_fields(work_path)
+
         # construct a context for this path to determine if it's in
         # a user sandbox or not:
         if env.context.user:
@@ -206,9 +210,6 @@ class InteractiveOpenAction(OpenFileAction):
                 # file is in a user sandbox - construct path
                 # for the current user's sandbox:
                 try:
-                    # get fields from work path:
-                    fields = env.work_template.get_fields(work_path)
-
                     # add in the fields from the context with the current user:
                     local_ctx = env.context.create_copy_for_user(current_user)
                     ctx_fields = local_ctx.as_template_fields(env.work_template)
@@ -249,7 +250,9 @@ class InteractiveOpenAction(OpenFileAction):
                     work_path = local_path
                     workfile_context = local_ctx
 
-        return self._do_copy_and_open(src_path, work_path, None, not file.editable,
+
+
+        return self._do_copy_and_open(src_path, work_path, fields.get("version"), not file.editable,
                                              env.context, parent_ui)
 
     def _open_previous_publish(self, file, env, parent_ui):
@@ -307,6 +310,9 @@ class InteractiveOpenAction(OpenFileAction):
         # trying to open a publish:
         work_path = None
         src_path = file.publish_path
+
+        # get fields for the path:
+        fields = env.publish_template.get_fields(src_path)
         
         # early check to see if the publish path & work path will actually be different:
         if env.publish_template == env.work_template and "version" not in env.publish_template.keys:
@@ -315,9 +321,6 @@ class InteractiveOpenAction(OpenFileAction):
         else:
             # get the work path for the publish:
             try:
-                # get fields for the path:                
-                fields = env.publish_template.get_fields(src_path)
-    
                 # construct a context for the path:
                 sp_ctx = self._app.sgtk.context_from_path(src_path, env.context)
     
@@ -342,4 +345,4 @@ class InteractiveOpenAction(OpenFileAction):
                 self._app.log_exception("Failed to resolve work file path from publish path: %s" % src_path)
                 return False
 
-        return self._do_copy_and_open(src_path, work_path, None, not file.editable, env.context, parent_ui)
+        return self._do_copy_and_open(src_path, work_path, fields.get("version"), not file.editable, env.context, parent_ui)

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -21,11 +21,11 @@ from ..user_cache import g_user_cache
 
 class InteractiveOpenAction(OpenFileAction):
 
-    def __init__(self, file, file_versions, environment, workfiles_visible, publishes_visible):
+    def __init__(self, file, file_versions, environment, workfiles_visible, publishes_visible, next_version_override):
         """
         """
-        OpenFileAction.__init__(self, "Open", file, file_versions, environment)
-        
+        OpenFileAction.__init__(self, "Open", file, file_versions, environment, next_version_override)
+
         self._workfiles_visible = workfiles_visible
         self._publishes_visible = publishes_visible
 
@@ -215,16 +215,8 @@ class InteractiveOpenAction(OpenFileAction):
                     ctx_fields = local_ctx.as_template_fields(env.work_template)
                     fields.update(ctx_fields)
                     if "version" in fields:
-                        try:
-                            fields["version"] = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
-                                # Name is not mandatory
-                                fields.get("name"),
-                                local_ctx,
-                                env.work_template
-                            )
-                        except NotImplementedError:
-                            # We keep the default value.
-                            pass
+                        if self._next_version_override is not None:
+                            fields["version"] = self._next_version_override
 
                     # construct the local path from these fields:
                     local_path = env.work_template.apply_fields(fields)
@@ -249,8 +241,6 @@ class InteractiveOpenAction(OpenFileAction):
                     src_path = work_path
                     work_path = local_path
                     workfile_context = local_ctx
-
-
 
         return self._do_copy_and_open(src_path, work_path, fields.get("version"), not file.editable,
                                              env.context, parent_ui)

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -28,6 +28,14 @@ class OpenFileAction(FileAction):
     """
 
     def __init__(self, label, file, file_versions, environment, next_version_override=None):
+        """
+        :params str label: Label of the menu item.
+        :param FileItem file: File the menu item is launched from.
+        :param file_versions: All the file versions, publishes and workfiles, associated with the selection.
+        :param environment: Environment associated with this file.
+        :param int next_version_override: Allows to override the next version for the current version
+            stream of this file.
+        """
         super(OpenFileAction, self).__init__(label, file, file_versions, environment)
         self._next_version_override = next_version_override
 
@@ -112,10 +120,6 @@ class OpenFileAction(FileAction):
                 return False            
 
             # Workfile was created on disk, we should register it with Shotgun.
-            # FIXME: Note that it's possible that opening the file might fail due to a software
-            # error in the following lines. It would probably be better at that point
-            # to delete the file and unregister the workfiles. For now we'll do no
-            # such thing and keep it registered, but it's worth keeping in mind for the future.
             try:
                 sgtk.platform.current_bundle().workfiles_management.register_workfile(
                     os.path.basename(dst_path), version,
@@ -268,6 +272,12 @@ class ContinueFromFileAction(OpenFileAction):
     """
     def __init__(self, label, file, file_versions, environment, next_version_override):
         """
+        :params str label: Label of the menu item.
+        :param FileItem file: File the menu item is launched from.
+        :param file_versions: All the file versions, publishes and workfiles, associated with the selection.
+        :param environment: Environment associated with this file.
+        :param int next_version_override: Allows to override the next version for the current version
+            stream of this file.
         """
         # Figure out what could be the default next version number.
         # Q. should the next version include the current version?
@@ -290,7 +300,7 @@ class ContinueFromFileAction(OpenFileAction):
                           "work template could be found" % src_path)
             return False
 
-    # build dst path for the next version of this file:
+        # build dst path for the next version of this file:
         fields = src_template.get_fields(src_path)
 
         # get the template fields for the current context using the current work template: 

--- a/python/tk_multi_workfiles/actions/open_file_action.py
+++ b/python/tk_multi_workfiles/actions/open_file_action.py
@@ -258,10 +258,10 @@ class CopyAndOpenInCurrentWorkAreaAction(OpenFileAction):
         # copy and open the file:
         return self._do_copy_and_open(src_path, 
                                       dst_file_path, 
-                                      version = fields.get("version"),
-                                      read_only = False, 
-                                      new_ctx = dst_work_area.context, 
-                                      parent_ui = parent_ui)
+                                      version=fields.get("version"),
+                                      read_only=False,
+                                      new_ctx=dst_work_area.context,
+                                      parent_ui=parent_ui)
 
 class ContinueFromFileAction(OpenFileAction):
     """

--- a/python/tk_multi_workfiles/actions/open_publish_actions.py
+++ b/python/tk_multi_workfiles/actions/open_publish_actions.py
@@ -51,13 +51,13 @@ class OpenPublishAction(OpenFileAction):
 class ContinueFromPublishAction(ContinueFromFileAction):
     """
     """
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, file, file_versions, environment, next_version_override):
         """
         """
         # This command does not pass down a next_version because it is assumed
         # that the publishes have all been retrieved from Shotgun, so therefore
         # the default behaviour from the base class of doing max + 1 works great.
-        ContinueFromFileAction.__init__(self, "Continue working from Publish in your Work Area", file, file_versions, environment)
+        ContinueFromFileAction.__init__(self, "Continue working from Publish in your Work Area", file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """
@@ -74,8 +74,8 @@ class ContinueFromPublishAction(ContinueFromFileAction):
 class CopyAndOpenPublishInCurrentWorkAreaAction(CopyAndOpenInCurrentWorkAreaAction):
     """
     """
-    def __init__(self, file, file_versions, environment):
-        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open Publish in Current Work Area...", file, file_versions, environment)
+    def __init__(self, file, file_versions, environment, next_version_override):
+        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open Publish in Current Work Area...", file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_publish_actions.py
+++ b/python/tk_multi_workfiles/actions/open_publish_actions.py
@@ -57,7 +57,7 @@ class ContinueFromPublishAction(ContinueFromFileAction):
         # This command does not pass down a next_version because it is assumed
         # that the publishes have all been retrieved from Shotgun, so therefore
         # the default behaviour from the base class of doing max + 1 works great.
-        ContinueFromFileAction.__init__(self, "Continue Working From Publish", file, file_versions, environment)
+        ContinueFromFileAction.__init__(self, "Continue working from Publish in your Work Area", file, file_versions, environment)
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -63,7 +63,7 @@ class OpenWorkfileAction(OpenFileAction):
 class ContinueFromWorkFileAction(ContinueFromFileAction):
     """
     """
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, file, file_versions, environment, next_version_override):
         """
         """
         label = ""
@@ -75,7 +75,7 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
         else:
             label = "Continue Working"
 
-        ContinueFromFileAction.__init__(self, label, file, file_versions, environment)
+        ContinueFromFileAction.__init__(self, label, file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """
@@ -94,10 +94,10 @@ class CopyAndOpenFileInCurrentWorkAreaAction(CopyAndOpenInCurrentWorkAreaAction)
     Action that copies a file to the current work area as the next available version
     and opens it from there
     """
-    def __init__(self, file, file_versions, environment):
+    def __init__(self, file, file_versions, environment, next_version_override):
         """
         """
-        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open in Current Work Area...", file, file_versions, environment)
+        CopyAndOpenInCurrentWorkAreaAction.__init__(self, "Open in Current Work Area...", file, file_versions, environment, next_version_override)
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -71,7 +71,7 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
             and environment.context and environment.context.user and g_user_cache.current_user
             and environment.context.user["id"] != g_user_cache.current_user["id"]):
             sandbox_user = environment.context.user.get("name", "Unknown").split(" ")[0]
-            label = "Continue Working from %s's File" % sandbox_user
+            label = "Continue Working from %s's Work File in your Work Area" % sandbox_user
         else:
             label = "Continue Working"
 

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -75,20 +75,7 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
         else:
             label = "Continue Working"
 
-        # Figure out what could be the default next version number.
-        try:
-            next_version = sgtk.platform.current_bundle().workfiles_management.get_next_workfile_version(
-                # Name is not mandatory
-                environment.work_template.get_fields(file.path).get("name"),
-                environment.context,
-                environment.work_template
-            )
-        except NotImplementedError:
-            next_version = None
-
-        ContinueFromFileAction.__init__(
-            self, label, file, file_versions, environment, next_version
-        )
+        ContinueFromFileAction.__init__(self, label, file, file_versions, environment)
 
     def execute(self, parent_ui):
         """

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -65,6 +65,11 @@ class ContinueFromWorkFileAction(ContinueFromFileAction):
     """
     def __init__(self, file, file_versions, environment, next_version_override):
         """
+        :param FileItem file: File the menu item is launched from.
+        :param file_versions: All the file versions, publishes and workfiles, associated with the selection.
+        :param environment: Environment associated with this file.
+        :param int next_version_override: Allows to override the next version for the current version
+            stream of this file.
         """
         label = ""
         if (environment and environment.contains_user_sandboxes


### PR DESCRIPTION
There were several fixes and optimizations done.
- Move the call to `workfiles_management.get_next_workfile_version` outside of the actions as the menu generation slowed down as more and more submenu-items were added.
- Centralized the registration logic deep into the FileOpenAction menu, where files are copied into another sandbox and need to be registered.
- Introduced a new setting that allows to hide publish actions on workfiles and vise-versa
- Clarified the text of actions that copy workfiles into your own sandbox.