### PR TITLE
SG-11483 improves the error logging when changing context.

### DIFF
--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -119,8 +119,8 @@ class FileAction(Action):
         try:
             sgtk.platform.change_context(ctx)
         except Exception, e:
-            app.log_exception("Context change failed!")
-            raise TankError("Failed to change work area - %s" % e)
+            app.log_exception(e)
+            raise TankError("Context changed failed, see log for details.")
         finally:
             QtGui.QApplication.restoreOverrideCursor()
 


### PR DESCRIPTION
This change means the full original error stack gets logged and we still raise an error with a more friendly message.
Previously we would only get the actual error message without a stack trace, which meant the error was too vague, and difficult to track down.