### PR TITLE
Fixed setIcon with pixmap error

### DIFF
--- a/python/tk_multi_workfiles/step_list_filter.py
+++ b/python/tk_multi_workfiles/step_list_filter.py
@@ -220,7 +220,7 @@ class StepListWidget(QtCore.QObject):
                 # color otherwise it is too bright.
                 color = [int(x) for x in step["color"].split(",")] + [200]
                 pixmap.fill(QtGui.QColor(*color))
-                widget.setIcon(pixmap)
+                widget.setIcon(QtGui.QIcon(pixmap))
             # Turn it on if it was in the step saved filters
             # We do this before the toggled signal is connected to not emit
             # un-wanted signals.


### PR DESCRIPTION
:zap: Super quick one! 

This patch fixes the following errors encountered as we try implement `tk-multi-workfiles2` "File Open..." dialog `tk-katana` for Katana 3.1 (PyQt5):

- [x ] `[ERROR python.root]: A TypeError occurred in "step_list_filter.py": setIcon(self, QIcon): argument 1 has unexpected type 'QPixmap'`
    ```python
    Traceback (most recent call last):
      File "/Volumes/wwfx/shotgun/test_project/joe/install/app_store/tk-multi-workfiles2/v0.11.10/python/tk_multi_workfiles/step_list_filter.py", line 154, in set_widgets_for_entity_type
        self._ensure_widgets_for_entity_type(linked_entity_type)
      File "/Volumes/wwfx/shotgun/test_project/joe/install/app_store/tk-multi-workfiles2/v0.11.10/python/tk_multi_workfiles/step_list_filter.py", line 223, in _ensure_widgets_for_entity_type
        widget.setIcon(pixmap)
    TypeError: setIcon(self, QIcon): argument 1 has unexpected type 'QPixmap'
    ```
