### PR TITLE
Fix issue when running custom_actions in DCCs based on PySide2

### DIFF
--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -297,8 +297,7 @@ class FileOpenForm(FileFormBase):
                 add_separators = True
             else:
                 q_action = QtGui.QAction(action.label, menu)
-                slot = lambda a=action, checked=False: self._perform_action(a)
-                q_action.triggered[()].connect(slot)
+                q_action.triggered[()].connect(lambda a=action, checked=False: self._perform_action(a))
                 menu.addAction(q_action)
                 add_separators = True
 

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -297,7 +297,7 @@ class FileOpenForm(FileFormBase):
                 add_separators = True
             else:
                 q_action = QtGui.QAction(action.label, menu)
-                slot = lambda a=action: self._perform_action(a)
+                slot = lambda a=action, checked=False: self._perform_action(a)
                 q_action.triggered[()].connect(slot)
                 menu.addAction(q_action)
                 add_separators = True


### PR DESCRIPTION
We found that those DCCs based on PySide2 the `custom_actions` don't work as expected. 

![image-2019-06-03-09-30-03-213](https://user-images.githubusercontent.com/2762494/58849651-c8730e80-8650-11e9-8fcf-68a5873a2da9.png)

When user clicks any of the menu options the signal is sent but the `_perform_action` method receives `False` instead of the action object.

The part of the code is located here:

https://github.com/shotgunsoftware/tk-multi-workfiles2/blob/master/python/tk_multi_workfiles/file_open_form.py#L300

We invested some time and tested this approach with successful results:

https://stackoverflow.com/questions/28318281/qaction-triggered-signal-is-not-passing-checked-parameter

Finally what we did:

Change:
`slot = lambda a=action: self._perform_action(a)`

With:
`slot = lambda a=action, checked=False: self._perform_action(a)`

And to avoid warning of assigning a lambda function to a variable, we then refined the expression with:
`q_action.triggered[()].connect(lambda a=action, checked=False: self._perform_action(a))`

**NOTE:** This change is backwards-compatible  with PySide1 and PySide2