### PR TITLE
SG-13565 Now uses the name passed from the filter hooks if provided

### DIFF
--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -283,10 +283,11 @@ class FileFinder(QtCore.QObject):
             if not file_details["modified_by"]:
                 file_details["modified_by"] = g_user_cache.get_file_last_modified_user(work_path)
 
-            # make sure all files with the same key have the same name:
-            file_details["name"] = name_map.get_name(
-                file_key, work_path, work_template, wf_fields
-            )
+            if not file_details["name"]:
+                # make sure all files with the same key have the same name:
+                file_details["name"] = name_map.get_name(
+                    file_key, work_path, work_template, wf_fields
+                )
 
             # add to the list of files
             files[(file_key, file_details["version"])] = {
@@ -365,8 +366,9 @@ class FileFinder(QtCore.QObject):
                 file_details["modified_at"] = sg_publish.get("published_at")
                 file_details["modified_by"] = sg_publish.get("published_by")
 
-            # make sure all files with the same key have the same name:
-            file_details["name"] = name_map.get_name(file_key, publish_path, publish_template, publish_fields)
+            if not file_details["name"]:
+                # make sure all files with the same key have the same name:
+                file_details["name"] = name_map.get_name(file_key, publish_path, publish_template, publish_fields)
 
             # add new file item for this publish.  Note that we also keep track of the
             # work path even though we don't know if this publish has a corresponding


### PR DESCRIPTION
The filter workfiles and publish hooks allow for customising data about the found files as well as filtering them out.

For example you can return a dictionary for each workfile or published file where you can adjust how they are renamed. However without this fix the `name` was ignored.

As an example if you had a workfiles filter hook that looked like this:

```python
import sgtk
HookClass = sgtk.get_hook_baseclass()

class FilterWorkFiles(HookClass):

    def execute(self, work_files, **kwargs):

        for a_workfile in work_files:
            a_workfile["work_file"]["name"] = "bob"
        return work_files
```

All workfiles would take on the name "bob", however without the fix the provided name would be ignored. With the fix it looks like this (all files were named "scene" previously):
<img width="158" alt="Shotgun__File_Open" src="https://user-images.githubusercontent.com/3777228/62721287-d2740d80-ba03-11e9-80a9-a579d2ddfc3d.png">
