### PR TITLE
Fix bootstrap error on Houdini deadline jobs.

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,15 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         Called as the application is being initialized
         """
+        
+        if self.engine.name == "tk-houdini":
+            # When Houdini is bootstrapped on a renderfarm, hython is used which has no gui causing workfiles2 to fail.
+            # Prevent loading of this app if no gui is detected.
+
+            import hou
+            if not hasattr(hou, 'ui'):
+                return
+        
         self._tk_multi_workfiles = self.import_module("tk_multi_workfiles")
         self.__is_pyside_unstable = None
 


### PR DESCRIPTION
Houdini deadline jobs uses hython.exe which has no gui and thus no Qt, which workfiles2 needs to load.
This update detects if the app is being loaded in to a houdini gui environment and skips initialising the app if this isn't the case.
This allows houdini to bootstrap SG on deadline without erroring.