### PR TITLE
use partial instead of lambda for menu actions

### DIFF
--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -13,6 +13,8 @@ Qt widget that presents the user with a list of work files and publishes
 so that they can choose one to open
 """
 
+from functools import partial
+
 import sgtk
 from sgtk.platform.qt import QtGui
 
@@ -299,7 +301,7 @@ class FileOpenForm(FileFormBase):
             else:
                 q_action = QtGui.QAction(action.label, menu)
                 q_action.triggered[()].connect(
-                    lambda a=action, checked=False: self._perform_action(a)
+                    partial(self._preform_action, action)
                 )
                 menu.addAction(q_action)
                 add_separators = True

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -301,7 +301,7 @@ class FileOpenForm(FileFormBase):
             else:
                 q_action = QtGui.QAction(action.label, menu)
                 q_action.triggered[()].connect(
-                    partial(self._preform_action, action)
+                    partial(self._perform_action, action)
                 )
                 menu.addAction(q_action)
                 add_separators = True


### PR DESCRIPTION
Our custom engine that uses the unreal qt5.6a framework had issues where the right click menu actions wouldn't trigger. Swapping the lambda with a partial fixed the issue.