### PR TITLE
[SHOT-2419] Have launch_at_startup for tk-multi-workfiles2 in Alias & VRED

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,7 +81,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         # the behaviour can be very different.
         #
         # currently, we have done QA on the following engines:
-        SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax"]
+        SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax", "tk-alias", "tk-vred"]
 
         if not hasattr(sgtk, "_tk_multi_workfiles2_launch_at_startup"):
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,5 @@ jobs:
   parameters:
     additional_repositories:
       - name: tk-framework-shotgunutils
-        ref: SG-13276-workfiles2-python3-port
       - name: tk-framework-widget
       - name: tk-framework-qtwidgets


### PR DESCRIPTION
Add **tk-alias** and **tk-vred** to the list of supported engines for the **launch_at_startup** option