### PR TITLE
[SG-39990] Process the TemplateKey value before storing it

### DIFF
--- a/python/tk_multi_workfiles/file_item.py
+++ b/python/tk_multi_workfiles/file_item.py
@@ -74,8 +74,9 @@ class FileItem(object):
             if name not in template_keys:
                 # skip fields that aren't included in the template
                 continue
-
-            file_key[name] = value
+            
+            # Ensure we process the value before storing it
+            file_key[name] = template_keys[name].str_from_value(value)
 
         # add in any 'default' values from the template that aren't explicitely ignored
         # or weren't specified in the input fields:

--- a/python/tk_multi_workfiles/file_item.py
+++ b/python/tk_multi_workfiles/file_item.py
@@ -74,7 +74,7 @@ class FileItem(object):
             if name not in template_keys:
                 # skip fields that aren't included in the template
                 continue
-            
+
             # Ensure we process the value before storing it
             file_key[name] = template_keys[name].str_from_value(value)
 


### PR DESCRIPTION

----
_NOTE: This is a replacement PR as we erroneously purged the repo from https://github.com/shotgunsoftware/tk-multi-workfiles2/pull/80 which should be closed in favor of this one)_

---

Fix for incorrect File Key being generated when `TemplateKeys` have additional parameters that require processing. Previously, the File Key would be generated using the raw values of the `TemplateKeys` - with this change it is generated with the processed value (using `str_from_value()`). 

The way this manifests itself, specifically when executing a File Save... The app uses the File Key to determine any matching files that are currently present on the filesystem. It then calculates the `version_number` by using the highest value for `version_number` from all files that exist with the given File Key, and adding 1. If no files are found matching the File Key, then `1` is used.

For a `TemplateKey` defined as so:

```yaml
    sg_asset_name_letter:
        type: str
        shotgun_entity_type: Asset
        shotgun_field_name: code
        subset: "(.{1}).*"
```

the raw value for `sg_asset_name_letter` will be "MyAssetName", while the *processed* value will be "M". (the subset isn't applied until you run `str_from_value()`). If your work template uses this key, when it writes out the files to the filesystem, they will be saved using "M" as the processed value. 

Then later when you execute a Save As... to try and version up, a File Key is generated for the current work file, which has `("sg_asset_name_letter", "MyAssetName")` in it. While the file saved on the filesystem will have `("sg_asset_name_letter", "M")` in the File Key and will not be considered the same file. Therefor it will be incorrectly ignored when calculating the next version number.

This fix ensures the File Key is generated with the *processed* value of the TemplateKeys so that they will always correctly match any files on the filesystem.

