### PR TITLE
[SHOT-3316] Use display name instead of entity name in the Workfiles app

### DIFF
--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -29,6 +29,10 @@ from ..util import (
 from ..util import get_sg_entity_name_field
 from ..entity_models import ShotgunDeferredEntityModel
 
+shotgun_globals = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils", "shotgun_globals"
+)
+
 
 class EntityTreeForm(QtGui.QWidget):
     """
@@ -846,7 +850,8 @@ class EntityTreeForm(QtGui.QWidget):
                 # expected key is present, use "name" if not.
                 if name_token not in entity:
                     name_token = "name"
-                label = "<b>%s</b> %s" % (entity["type"], entity.get(name_token))
+                display_type = shotgun_globals.get_type_display_name(entity["type"])
+                label = "<b>%s</b> %s" % (display_type, entity.get(name_token))
                 breadcrumbs.append(EntityTreeForm._EntityBreadcrumb(label, entity))
             else:
                 label = get_model_str(src_index)


### PR DESCRIPTION
In the workfile breadcrumbs, use the entity display name instead of its type to make the navigation easier

![image](https://user-images.githubusercontent.com/38566472/78648343-20efe980-78bc-11ea-83d1-6d6755e8be09.png)

will become 

![image](https://user-images.githubusercontent.com/38566472/78648880-ed618f00-78bc-11ea-81ce-1f92253a200b.png)
