### PR TITLE
SG-17473 Increases the maximum save version value to 9999

### DIFF
--- a/python/tk_multi_workfiles/ui/file_save_form.py
+++ b/python/tk_multi_workfiles/ui/file_save_form.py
@@ -123,6 +123,7 @@ class Ui_FileSaveForm(object):
         self.horizontalLayout_2.setSpacing(-1)
         self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.version_spinner = QtGui.QSpinBox(FileSaveForm)
+        self.version_spinner.setMaximum(9999)
         self.version_spinner.setObjectName("version_spinner")
         self.horizontalLayout_2.addWidget(self.version_spinner)
         self.use_next_available_cb = QtGui.QCheckBox(FileSaveForm)

--- a/python/tk_multi_workfiles/ui/file_save_form.py
+++ b/python/tk_multi_workfiles/ui/file_save_form.py
@@ -123,7 +123,7 @@ class Ui_FileSaveForm(object):
         self.horizontalLayout_2.setSpacing(-1)
         self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.version_spinner = QtGui.QSpinBox(FileSaveForm)
-        self.version_spinner.setMaximum(9999)
+        self.version_spinner.setMaximum(9999999)
         self.version_spinner.setObjectName("version_spinner")
         self.horizontalLayout_2.addWidget(self.version_spinner)
         self.use_next_available_cb = QtGui.QCheckBox(FileSaveForm)

--- a/resources/file_save_form.ui
+++ b/resources/file_save_form.ui
@@ -236,7 +236,7 @@ background-color: rgb(255, 128, 0);
          <item>
           <widget class="QSpinBox" name="version_spinner">
            <property name="maximum">
-            <number>9999</number>
+            <number>9999999</number>
            </property>
           </widget>
          </item>

--- a/resources/file_save_form.ui
+++ b/resources/file_save_form.ui
@@ -234,7 +234,11 @@ background-color: rgb(255, 128, 0);
           <number>-1</number>
          </property>
          <item>
-          <widget class="QSpinBox" name="version_spinner"/>
+          <widget class="QSpinBox" name="version_spinner">
+           <property name="maximum">
+            <number>9999</number>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="use_next_available_cb">


### PR DESCRIPTION
It now allows the user to save a file with a version number of up to 9999.
It was requested by users that we allow files with three decimal places, I figured giving four gives a bit more headroom just in case.