### PR TITLE
Added save name label option

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -13,6 +13,13 @@
 # expected fields in the configuration file for this app
 configuration:
 
+    # WWFX: Save Name label
+    #
+    save_name_label:
+      type: str
+      description: Custom save dialog "Name" label text.
+      default_value: Name
+
     # Startup options
     #
 

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -646,6 +646,23 @@ class FileSaveForm(FileFormBase):
                     name = self._current_env.save_as_default_name or "scene"
                 self._ui.name_edit.setText(name)
 
+                # Setup custom name label if any.
+                # See also ./ui/file_save_form.py:retranslateUi()
+                app = sgtk.platform.current_bundle()
+                label_template = (
+                    '<html><head/><body><p><span style=" font-weight:600;">'
+                    "{}:</span></p></body></html>"
+                )
+                # Catch even if save_name_label is an empty string.
+                label_text = app.get_setting("save_name_label") or "Name"
+                text = QtGui.QApplication.translate(
+                    "FileSaveForm",
+                    label_template.format(label_text),
+                    None,
+                    QtGui.QApplication.UnicodeUTF8,
+                )
+                self._ui.name_label.setText(text)
+
             self._ui.name_label.setVisible(name_is_used)
             self._ui.name_edit.setVisible(name_is_used)
 


### PR DESCRIPTION
### Added

- `save_name_label` config to edit visually the save "Name" label to be something else more meaningful for the artists.

![image](https://user-images.githubusercontent.com/9294702/74364876-e179b500-4dc4-11ea-841e-d5027f9212c9.png)
