### PR TITLE
Add parameter to opening dialogs to specify modal or not.

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,17 +109,17 @@ class MultiWorkFiles(sgtk.platform.Application):
         """
         self.log_debug("Destroying tk-multi-workfiles2")
 
-    def show_file_open_dlg(self):
+    def show_file_open_dlg(self, use_modal_dialog=False):
         """
         Launch the main File Open UI
         """
-        self._tk_multi_workfiles.WorkFiles.show_file_open_dlg()
+        self._tk_multi_workfiles.WorkFiles.show_file_open_dlg(use_modal_dialog)
 
-    def show_file_save_dlg(self):
+    def show_file_save_dlg(self, use_modal_dialog=False):
         """
         Launch the main File Save UI
         """
-        self._tk_multi_workfiles.WorkFiles.show_file_save_dlg()
+        self._tk_multi_workfiles.WorkFiles.show_file_save_dlg(use_modal_dialog)
 
     @property
     def context_change_allowed(self):

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -78,7 +78,7 @@ class WorkFiles(object):
     Main entry point for all commands in the app.
     """
 
-    def __init__(self):
+    def __init__(self, use_modal_dialog=False):
         """
         Constructor.
         """
@@ -91,25 +91,27 @@ class WorkFiles(object):
         # with memory leak-detection code.
         if app.use_debug_dialog:
             self._dialog_launcher = dbg_info(app.engine.show_modal)
+        elif use_modal_dialog:
+            self._dialog_launcher = app.engine.show_modal
         else:
             self._dialog_launcher = app.engine.show_dialog
 
     @staticmethod
-    def show_file_open_dlg():
+    def show_file_open_dlg(use_modal_dialog=False):
         """
         Show the file open dialog
         """
-        handler = WorkFiles()
+        handler = WorkFiles(use_modal_dialog)
         from .file_open_form import FileOpenForm
 
         handler._show_file_dlg("File Open", FileOpenForm)
 
     @staticmethod
-    def show_file_save_dlg():
+    def show_file_save_dlg(use_modal_dialog=False):
         """
         Show the file save dialog
         """
-        handler = WorkFiles()
+        handler = WorkFiles(use_modal_dialog)
         from .file_save_form import FileSaveForm
 
         handler._show_file_dlg("File Save", FileSaveForm)


### PR DESCRIPTION
@jfboismenu we'd like to add a parameter to the show dialog methods in the Workfiles2 app so that we can choose whether or not to open these dialogs in modal mode. There's a situation that came up for VRED when we need the Workfiles2 save dialog to be modal.