### PR TITLE
SG-15693 add change context mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,11 +32,6 @@ class MultiWorkFiles(sgtk.platform.Application):
             )
             return
 
-        if self.engine.name == "tk-mari":
-            # Mari doesn't have the concept of a current scene so this app shouldn't
-            # provide any commands!
-            return
-
         if self.get_setting("show_change_context"):
             # This will only show the context change dialog and not register the save of open dialogs.
             self.engine.register_command(

--- a/app.py
+++ b/app.py
@@ -56,6 +56,24 @@ class MultiWorkFiles(sgtk.platform.Application):
             },
         )
 
+        self.engine.register_command(
+            "Change Context...",
+            self.show_context_change_dlg,
+            {
+                "short_name": "change_context",
+                # dark themed icon for engines that recognize this format
+                "icons": {
+                    "dark": {
+                        "png": os.path.join(
+                            os.path.dirname(__file__),
+                            "resources",
+                            "file_open_menu_icon.png",
+                        )
+                    }
+                },
+            },
+        )
+
         # register the file save command
         self.engine.register_command(
             "File Save...",
@@ -114,6 +132,12 @@ class MultiWorkFiles(sgtk.platform.Application):
         Launch the main File Open UI
         """
         self._tk_multi_workfiles.WorkFiles.show_file_open_dlg()
+
+    def show_context_change_dlg(self):
+        """
+        Launch the main File Open UI
+        """
+        self._tk_multi_workfiles.WorkFiles.show_context_change_dlg()
 
     def show_file_save_dlg(self):
         """

--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ class MultiWorkFiles(sgtk.platform.Application):
             # provide any commands!
             return
 
-        if self.get_setting("context_change_only_mode"):
+        if self.get_setting("show_change_context"):
             # This will only show the context change dialog and not register the save of open dialogs.
             self.engine.register_command(
                 "Change Context...",
@@ -56,7 +56,7 @@ class MultiWorkFiles(sgtk.platform.Application):
                     },
                 },
             )
-        else:
+        if self.get_setting("show_file_open"):
             # This show the open and save dialogs and not the context change dialog.
             # register the file open command
             self.engine.register_command(
@@ -77,6 +77,7 @@ class MultiWorkFiles(sgtk.platform.Application):
                 },
             )
 
+        if self.get_setting("show_file_save"):
             # register the file save command
             self.engine.register_command(
                 "File Save...",

--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ class MultiWorkFiles(sgtk.platform.Application):
                     },
                 },
             )
-            # else:
+        else:
             # This show the open and save dialogs and not the context change dialog.
             # register the file open command
             self.engine.register_command(

--- a/app.py
+++ b/app.py
@@ -37,61 +37,64 @@ class MultiWorkFiles(sgtk.platform.Application):
             # provide any commands!
             return
 
-        # register the file open command
-        self.engine.register_command(
-            "File Open...",
-            self.show_file_open_dlg,
-            {
-                "short_name": "file_open",
-                # dark themed icon for engines that recognize this format
-                "icons": {
-                    "dark": {
-                        "png": os.path.join(
-                            os.path.dirname(__file__),
-                            "resources",
-                            "file_open_menu_icon.png",
-                        )
-                    }
+        if self.get_setting("context_change_only_mode"):
+            # This will only show the context change dialog and not register the save of open dialogs.
+            self.engine.register_command(
+                "Change Context...",
+                self.show_context_change_dlg,
+                {
+                    "short_name": "change_context",
+                    # dark themed icon for engines that recognize this format
+                    "icons": {
+                        "dark": {
+                            "png": os.path.join(
+                                os.path.dirname(__file__),
+                                "resources",
+                                "file_open_menu_icon.png",
+                            )
+                        }
+                    },
                 },
-            },
-        )
+            )
+            # else:
+            # This show the open and save dialogs and not the context change dialog.
+            # register the file open command
+            self.engine.register_command(
+                "File Open...",
+                self.show_file_open_dlg,
+                {
+                    "short_name": "file_open",
+                    # dark themed icon for engines that recognize this format
+                    "icons": {
+                        "dark": {
+                            "png": os.path.join(
+                                os.path.dirname(__file__),
+                                "resources",
+                                "file_open_menu_icon.png",
+                            )
+                        }
+                    },
+                },
+            )
 
-        self.engine.register_command(
-            "Change Context...",
-            self.show_context_change_dlg,
-            {
-                "short_name": "change_context",
-                # dark themed icon for engines that recognize this format
-                "icons": {
-                    "dark": {
-                        "png": os.path.join(
-                            os.path.dirname(__file__),
-                            "resources",
-                            "file_open_menu_icon.png",
-                        )
-                    }
+            # register the file save command
+            self.engine.register_command(
+                "File Save...",
+                self.show_file_save_dlg,
+                {
+                    "short_name": "file_save",
+                    # dark themed icon for engines that recognize this format
+                    "icons": {
+                        "dark": {
+                            "png": os.path.join(
+                                os.path.dirname(__file__),
+                                "resources",
+                                "file_save_menu_icon.png",
+                            )
+                        }
+                    },
                 },
-            },
-        )
-
-        # register the file save command
-        self.engine.register_command(
-            "File Save...",
-            self.show_file_save_dlg,
-            {
-                "short_name": "file_save",
-                # dark themed icon for engines that recognize this format
-                "icons": {
-                    "dark": {
-                        "png": os.path.join(
-                            os.path.dirname(__file__),
-                            "resources",
-                            "file_save_menu_icon.png",
-                        )
-                    }
-                },
-            },
-        )
+            )
 
         # Process auto startup options - but only on certain supported platforms
         # because of the way QT inits and connects to different host applications

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        threshold: 0.5%
+        base: auto
+        only_pulls: true

--- a/hooks/scene_operation_tk-mari.py
+++ b/hooks/scene_operation_tk-mari.py
@@ -63,5 +63,6 @@ class SceneOperation(HookClass):
                                 all others     - None
         """
 
-        # Mari doesn't have any scene operations.
+        # Mari doesn't have any scene operations, since it only works with the context change mode.
+        # However workfiles does require that it can find the hook, so this is a placeholder hook.
         pass

--- a/hooks/scene_operation_tk-mari.py
+++ b/hooks/scene_operation_tk-mari.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import maya.cmds as cmds
+
+import sgtk
+from sgtk.platform.qt import QtGui
+
+HookClass = sgtk.get_hook_baseclass()
+
+
+class SceneOperation(HookClass):
+    """
+    Hook called to perform an operation with the
+    current scene
+    """
+
+    def execute(
+        self,
+        operation,
+        file_path,
+        context,
+        parent_action,
+        file_version,
+        read_only,
+        **kwargs
+    ):
+        """
+        Main hook entry point
+
+        :param operation:       String
+                                Scene operation to perform
+
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as
+                                - version_up
+
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+
+        :param read_only:       Specifies if the file should be opened read-only or not
+
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                 file path as a String
+                                'reset'        - True if scene was reset to an empty
+                                                 state, otherwise False
+                                all others     - None
+        """
+
+        pass

--- a/hooks/scene_operation_tk-mari.py
+++ b/hooks/scene_operation_tk-mari.py
@@ -8,10 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import maya.cmds as cmds
-
 import sgtk
-from sgtk.platform.qt import QtGui
 
 HookClass = sgtk.get_hook_baseclass()
 
@@ -66,4 +63,5 @@ class SceneOperation(HookClass):
                                 all others     - None
         """
 
+        # Mari doesn't have any scene operations.
         pass

--- a/info.yml
+++ b/info.yml
@@ -16,6 +16,14 @@ configuration:
     # Startup options
     #
 
+    context_change_only_mode:
+      type: bool
+      description: A flag to enable context change mode for the app. When true the open and save windows
+                   will not be available, and instead a context change window is provided where the user
+                   can pick an entity to change context to without opening a file.
+
+      default_value: False
+
     launch_at_startup:
         type: bool
         description: A flag whether to launch the UI at application startup.

--- a/info.yml
+++ b/info.yml
@@ -16,13 +16,23 @@ configuration:
     # Startup options
     #
 
-    context_change_only_mode:
+    show_change_context:
       type: bool
-      description: A flag to enable context change mode for the app. When true the open and save windows
-                   will not be available, and instead a context change window is provided where the user
+      description: A flag to enable the context change dialog. A context change window is provided where the user
                    can pick an entity to change context to without opening a file.
-
       default_value: False
+
+    show_file_open:
+      type: bool
+      description: A flag to enable the open file dialog. A open file window is provided where the user
+        can pick an entity and select the files associated with that context to open run other actions on.
+      default_value: True
+
+    show_file_save:
+      type: bool
+      description: A flag to enable the save file dialog. A save file window is provided where the user
+        can save the current workfile to the Toolkit templated folder structure.
+      default_value: True
 
     launch_at_startup:
         type: bool

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -35,7 +35,7 @@ class ContextChangeAction(Action):
 
     def execute(self, parent_ui):
         """
-        Perform a new-scene operation initialized with the current context.
+        Perform a context change operation.
 
         :param parent_ui: Parent dialog executing this action.
         """

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -44,9 +44,7 @@ class ContextChangeAction(Action):
             # create folders and validate that we can save using the work template:
             try:
                 # create folders if needed:
-                FileAction.create_folders_if_needed(
-                    self._environment.context, self._environment.work_template
-                )
+                FileAction.create_folders(self._environment.context)
 
             except TankError:
                 # log the original exception (useful for tracking down the problem)

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Action to create a new file.
+Action to create a change context.
 """
 
 from sgtk import TankError

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -59,7 +59,7 @@ class ContextChangeAction(Action):
         except Exception as e:
             error_title = "Failed to complete '%s' action" % self.label
             QtGui.QMessageBox.information(
-                parent_ui, "%s" % error_title, "%s:\n\n%s" % (error_title, e)
+                parent_ui, error_title, "%s:\n\n%s" % (error_title, e)
             )
             self._app.log_exception(error_title)
             return False

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -28,7 +28,7 @@ class ContextChangeAction(Action):
         """
         Constructor.
 
-        :param environment: A WorkArea instance of where the new file will go.
+        :param environment: A WorkArea instance containing the context we will switch to.
         """
         Action.__init__(self, "Change Context")
         self._environment = environment
@@ -47,7 +47,6 @@ class ContextChangeAction(Action):
                 FileAction.create_folders_if_needed(
                     self._environment.context, self._environment.work_template
                 )
-                # and double check that we can get all context fields for the work template:
 
             except TankError:
                 # log the original exception (useful for tracking down the problem)

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Action to create a new file.
+"""
+
+from sgtk import TankError
+from sgtk.platform.qt import QtGui
+
+from .file_action import FileAction
+from .action import Action
+
+
+class ContextChangeAction(Action):
+    """
+    This action changes the current engine context.
+    """
+
+    def __init__(self, environment):
+        """
+        Constructor.
+
+        :param environment: A WorkArea instance of where the new file will go.
+        """
+        Action.__init__(self, "Change Context")
+        self._environment = environment
+
+    def execute(self, parent_ui):
+        """
+        Perform a new-scene operation initialized with the current context.
+
+        :param parent_ui: Parent dialog executing this action.
+        """
+
+        try:
+            # create folders and validate that we can save using the work template:
+            try:
+                # create folders if needed:
+                FileAction.create_folders_if_needed(
+                    self._environment.context, self._environment.work_template
+                )
+                # and double check that we can get all context fields for the work template:
+
+            except TankError as e:
+                # log the original exception (useful for tracking down the problem)
+                self._app.log_exception("Unable to run folder creation!")
+
+            if not self._environment.context == self._app.context:
+                # Change context
+                FileAction.change_context(self._environment.context)
+
+        except Exception as e:
+            error_title = "Failed to complete '%s' action" % self.label
+            QtGui.QMessageBox.information(
+                parent_ui, "%s" % error_title, "%s:\n\n%s" % (error_title, e)
+            )
+            self._app.log_exception(error_title)
+            return False
+
+        return True

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Shotgun Software Inc.
+# Copyright (c) 2020 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #

--- a/python/tk_multi_workfiles/actions/context_change_action.py
+++ b/python/tk_multi_workfiles/actions/context_change_action.py
@@ -49,7 +49,7 @@ class ContextChangeAction(Action):
                 )
                 # and double check that we can get all context fields for the work template:
 
-            except TankError as e:
+            except TankError:
                 # log the original exception (useful for tracking down the problem)
                 self._app.log_exception("Unable to run folder creation!")
 

--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -100,7 +100,7 @@ class NewFileAction(Action):
         except Exception as e:
             error_title = "Failed to complete '%s' action" % self.label
             QtGui.QMessageBox.information(
-                parent_ui, "%s" % error_title, "%s:\n\n%s" % (error_title, e)
+                parent_ui, error_title, "%s:\n\n%s" % (error_title, e)
             )
             self._app.log_exception(error_title)
             return False

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -83,6 +83,8 @@ class BrowserForm(QtGui.QWidget):
     entity_type_focus_changed = QtCore.Signal(object)  # entity type
     step_filter_changed = QtCore.Signal(list)  # SG filter
 
+    task_double_clicked = QtCore.Signal(object)  # My tasks task double clicked
+
     def __init__(self, parent):
         """
         Construction
@@ -214,6 +216,7 @@ class BrowserForm(QtGui.QWidget):
                 my_tasks_model, allow_task_creation, parent=self
             )
             self._my_tasks_form.entity_selected.connect(self._on_entity_selected)
+            self._my_tasks_form.task_double_clicked.connect(self.task_double_clicked)
             self._ui.task_browser_tabs.addTab(self._my_tasks_form, "My Tasks")
             self._my_tasks_form.create_new_task.connect(self.create_new_task)
 

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -292,6 +292,8 @@ class BrowserForm(QtGui.QWidget):
                         ", ".join(list(self.TAB_INFO)),
                     )
                 )
+        else:
+            self._ui.file_browser_tabs.hide()
 
     def _add_file_list_form(
         self, tab_name, search_label, show_work_files, show_publishes

--- a/python/tk_multi_workfiles/context_change_form.py
+++ b/python/tk_multi_workfiles/context_change_form.py
@@ -29,11 +29,14 @@ class ContextChangeForm(FileFormBase):
             # doing this inside a try-except to ensure any exceptions raised don't
             # break the UI and crash the dcc horribly!
             self._do_init()
-        except:
+        except Exception:
             app = sgtk.platform.current_bundle()
             app.log_exception("Unhandled exception during Form construction!")
 
     def init_ui_file(self):
+        """
+        Returns the ui class to use, required by the base class.
+        """
         return Ui_FileOpenForm()
 
     def _do_init(self):
@@ -51,6 +54,7 @@ class ContextChangeForm(FileFormBase):
 
         # hook up signals on controls:
         self._ui.change_ctx_btn.clicked.connect(self._on_context_change)
+        self._ui.browser.task_double_clicked.connect(self._on_context_change)
 
         self._ui.browser.set_models(
             self._my_tasks_model, self._entity_models, None,
@@ -70,13 +74,20 @@ class ContextChangeForm(FileFormBase):
         self._update_change_context_btn(env_details)
 
     def _update_change_context_btn(self, env):
+        """
+        Updates the current selected context, and updates the context change button state.
+        When no environment is gathered from the context change button is disabled.
+        """
         self._context_change_env = env
         if env:
             self._ui.change_ctx_btn.setEnabled(True)
         else:
             self._ui.change_ctx_btn.setEnabled(False)
 
-    def _on_context_change(self):
+    def _on_context_change(self, *_args):
+        """
+        Calls the context change action which will change the current engine's context and close the dialog.
+        """
         context_change_action = ContextChangeAction(self._context_change_env)
 
         self._perform_action(context_change_action)

--- a/python/tk_multi_workfiles/context_change_form.py
+++ b/python/tk_multi_workfiles/context_change_form.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Qt widget that presents the user with a list of entities
+so that they can choose a context to work in.
+"""
+import sgtk
+
+from .actions.context_change_action import ContextChangeAction
+from .file_form_base import FileFormBase
+from .ui.file_open_form import Ui_FileOpenForm
+
+
+class ContextChangeForm(FileFormBase):
+    def __init__(self, parent=None):
+        super(ContextChangeForm, self).__init__(parent)
+
+        self._context_change_env = None
+
+        try:
+            # doing this inside a try-except to ensure any exceptions raised don't
+            # break the UI and crash the dcc horribly!
+            self._do_init()
+        except:
+            app = sgtk.platform.current_bundle()
+            app.log_exception("Unhandled exception during Form construction!")
+
+    def init_ui_file(self):
+        return Ui_FileOpenForm()
+
+    def _do_init(self):
+        """
+        """
+        super(ContextChangeForm, self)._do_init()
+
+        app = sgtk.platform.current_bundle()
+
+        # start by disabling buttons:
+        self._ui.open_btn.hide()
+        self._ui.new_file_btn.hide()
+        self._ui.change_ctx_btn.setEnabled(False)
+        self._ui.open_options_btn.hide()
+
+        # hook up signals on controls:
+        self._ui.change_ctx_btn.clicked.connect(self._on_context_change)
+
+        self._ui.browser.set_models(
+            self._my_tasks_model, self._entity_models, None,
+        )
+
+        # initialize the browser widget:
+        self._ui.browser.select_work_area(app.context)
+
+    def _on_browser_work_area_changed(self, entity, breadcrumbs):
+        """
+        Slot triggered whenever the work area is changed in the browser.
+        """
+        env_details = super(ContextChangeForm, self)._on_browser_work_area_changed(
+            entity, breadcrumbs
+        )
+
+        self._update_change_context_btn(env_details)
+
+    def _update_change_context_btn(self, env):
+        self._context_change_env = env
+        if env:
+            self._ui.change_ctx_btn.setEnabled(True)
+        else:
+            self._ui.change_ctx_btn.setEnabled(False)
+
+    def _on_context_change(self):
+        context_change_action = ContextChangeAction(self._context_change_env)
+
+        self._perform_action(context_change_action)

--- a/python/tk_multi_workfiles/context_change_form.py
+++ b/python/tk_multi_workfiles/context_change_form.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Shotgun Software Inc.
+# Copyright (c) 2020 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #

--- a/python/tk_multi_workfiles/context_change_form.py
+++ b/python/tk_multi_workfiles/context_change_form.py
@@ -44,8 +44,6 @@ class ContextChangeForm(FileFormBase):
         """
         super(ContextChangeForm, self)._do_init()
 
-        app = sgtk.platform.current_bundle()
-
         # start by disabling buttons:
         self._ui.open_btn.hide()
         self._ui.new_file_btn.hide()
@@ -61,6 +59,7 @@ class ContextChangeForm(FileFormBase):
         )
 
         # initialize the browser widget:
+        app = sgtk.platform.current_bundle()
         self._ui.browser.select_work_area(app.context)
 
     def _on_browser_work_area_changed(self, entity, breadcrumbs):

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -86,8 +86,6 @@ class FileFormBase(QtGui.QWidget):
             osx_f5_refresh_action.triggered.connect(self._on_refresh_triggered)
             self.addAction(osx_f5_refresh_action)
 
-        app = sgtk.platform.current_bundle()
-
     def _do_init(self):
         """
         """

--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -36,6 +36,7 @@ from .scene_operation import get_current_path, SAVE_FILE_AS_ACTION
 from .file_item import FileItem
 from .work_area import WorkArea
 from .actions.new_task_action import NewTaskAction
+from .actions.file_action import FileAction
 from .user_cache import g_user_cache
 from .util import monitor_qobject_lifetime, resolve_filters, get_sg_entity_name_field
 from .step_list_filter import get_saved_step_filter
@@ -56,6 +57,8 @@ class FileFormBase(QtGui.QWidget):
         QtGui.QWidget.__init__(self, parent)
 
         self._current_file = None
+        self._navigating = False
+        self._exit_code = QtGui.QDialog.Rejected
 
         # create a single instance of the task manager that manages all
         # asynchrounous work/tasks.
@@ -83,6 +86,27 @@ class FileFormBase(QtGui.QWidget):
             osx_f5_refresh_action.triggered.connect(self._on_refresh_triggered)
             self.addAction(osx_f5_refresh_action)
 
+        app = sgtk.platform.current_bundle()
+
+    def _do_init(self):
+        """
+        """
+
+        # set up the UI
+        self._ui = self.init_ui_file()
+        self._ui.setupUi(self)
+
+        # hook up signals on controls:
+        self._ui.cancel_btn.clicked.connect(self._on_cancel)
+        self._ui.browser.create_new_task.connect(self._on_create_new_task)
+        self._ui.browser.work_area_changed.connect(self._on_browser_work_area_changed)
+        self._ui.browser.step_filter_changed.connect(self._apply_step_filtering)
+        self._ui.nav.navigate.connect(self._on_navigate)
+        self._ui.nav.home_clicked.connect(self._on_navigate_home)
+
+    def init_ui_file(self):
+        raise NotImplementedError
+
     def closeEvent(self, event):
         """
         Overriden method triggered when the widget is closed.  Cleans up as much as possible
@@ -90,6 +114,9 @@ class FileFormBase(QtGui.QWidget):
 
         :param event:   Close event
         """
+
+        # clean up the browser:
+        self._ui.browser.shut_down()
 
         # clear up the various data models:
         if self._file_model:
@@ -284,6 +311,62 @@ class FileFormBase(QtGui.QWidget):
         app.log_debug("Path cache up to date!")
         self._refresh_all_async()
 
+    def _on_browser_work_area_changed(self, entity, breadcrumbs):
+        """
+        Slot triggered whenever the work area is changed in the browser.
+        """
+        env_details = None
+        if entity:
+            # (AD) - we need to build a context and construct the environment details
+            # instance for it but this may be slow enough that we should cache it!
+            # Keep an eye on it and consider threading if it's noticeably slow!
+            app = sgtk.platform.current_bundle()
+            context = app.sgtk.context_from_entity_dictionary(entity)
+            try:
+                env_details = WorkArea(context)
+            except sgtk.TankError:
+                # We can ignore the error reporting here. The browser is already
+                # updating it's various file views and they will display the same
+                # error. Which is good, because file open dialog doesn't have a
+                # widget dedicated to error reporting.
+                env_details = None
+
+        if not self._navigating:
+            destination_label = breadcrumbs[-1].label if breadcrumbs else "..."
+            self._ui.nav.add_destination(destination_label, breadcrumbs)
+        self._ui.breadcrumbs.set(breadcrumbs)
+
+        return env_details
+
+    def _on_navigate(self, breadcrumb_trail):
+        """
+        """
+        if not breadcrumb_trail:
+            return
+
+        # awesome, just navigate to the breadcrumbs:
+        self._ui.breadcrumbs.set(breadcrumb_trail)
+        self._navigating = True
+        try:
+            self._ui.browser.navigate_to(breadcrumb_trail)
+        finally:
+            self._navigating = False
+
+    def _on_navigate_home(self):
+        """
+        Navigate to the current work area
+        """
+        # navigate to the current work area in the browser:
+        app = sgtk.platform.current_bundle()
+        self._ui.browser.select_work_area(app.context)
+
+    def _on_cancel(self):
+        """
+        Called when the cancel button is clicked
+        """
+        self._exit_code = QtGui.QDialog.Rejected
+        self.close()
+
     def _refresh_all_async(self):
         """
         Asynchrounously refresh all models.
@@ -388,3 +471,35 @@ class FileFormBase(QtGui.QWidget):
         for _, _, model in self._entity_models:
             if model.supports_step_filtering:
                 model.update_filters(step_filter)
+
+    def _perform_action(self, action):
+        """
+        """
+        if not action:
+            return
+
+        # some debug:
+        app = sgtk.platform.current_bundle()
+        if isinstance(action, FileAction) and action.file:
+            app.log_debug(
+                "Performing action '%s' on file '%s, v%03d'"
+                % (action.label, action.file.name, action.file.version)
+            )
+        else:
+            app.log_debug("Performing action '%s'" % action.label)
+
+        # execute the action:
+        close_dialog = action.execute(self)
+
+        # if this is successful then close the form:
+        if close_dialog:
+            self._exit_code = QtGui.QDialog.Accepted
+            self.close()
+        else:
+            # refresh all models in case something changed as a result of
+            # the action (especially important with custom actions):
+            self._refresh_all_async()
+
+    @property
+    def exit_code(self):
+        return self._exit_code

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -87,6 +87,8 @@ class FileOpenForm(FileFormBase):
             self._my_tasks_model, self._entity_models, self._file_model,
         )
         current_file = self._get_current_file()
+        app = sgtk.platform.current_bundle()
+        self._ui.browser.select_work_area(app.context)
         self._ui.browser.select_file(current_file, app.context)
 
     def _is_using_user_sandboxes(self):

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -46,11 +46,14 @@ class FileOpenForm(FileFormBase):
             # doing this inside a try-except to ensure any exceptions raised don't
             # break the UI and crash the dcc horribly!
             self._do_init()
-        except:
+        except Exception:
             app = sgtk.platform.current_bundle()
             app.log_exception("Unhandled exception during Form construction!")
 
     def init_ui_file(self):
+        """
+        Returns the ui class to use, required by the base class.
+        """
         return Ui_FileOpenForm()
 
     def _do_init(self):

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -34,14 +34,18 @@ class FileOpenForm(FileFormBase):
     so that they can choose one to open in addition to any other user-definable actions.
     """
 
+    FILE_MODE = 0
+    CONTEXT_MODE = 1
+
     @property
     def exit_code(self):
         return self._exit_code
 
-    def __init__(self, parent=None):
+    def __init__(self, open_mode, parent=None):
         """
         Construction
         """
+        print(open_mode, parent)
         app = sgtk.platform.current_bundle()
 
         FileFormBase.__init__(self, parent)
@@ -56,11 +60,11 @@ class FileOpenForm(FileFormBase):
         try:
             # doing this inside a try-except to ensure any exceptions raised don't
             # break the UI and crash the dcc horribly!
-            self._do_init()
+            self._do_init(open_mode)
         except:
             app.log_exception("Unhandled exception during File Open Form construction!")
 
-    def _do_init(self):
+    def _do_init(self, open_mode):
         """
         """
         app = sgtk.platform.current_bundle()
@@ -79,7 +83,11 @@ class FileOpenForm(FileFormBase):
         # hook up signals on controls:
         self._ui.cancel_btn.clicked.connect(self._on_cancel)
         self._ui.open_btn.clicked.connect(self._on_open)
-        self._ui.new_file_btn.clicked.connect(self._on_new_file)
+
+        if open_mode == self.FILE_MODE:
+            self._ui.new_file_btn.clicked.connect(self._on_new_file)
+        else:
+            self._ui.new_file_btn.hide()
 
         self._ui.browser.file_context_menu_requested.connect(
             self._on_browser_context_menu_requested
@@ -99,7 +107,9 @@ class FileOpenForm(FileFormBase):
         # initialize the browser widget:
         self._ui.browser.show_user_filtering_widget(self._is_using_user_sandboxes())
         self._ui.browser.set_models(
-            self._my_tasks_model, self._entity_models, self._file_model
+            self._my_tasks_model,
+            self._entity_models,
+            self._file_model if open_mode == self.FILE_MODE else None,
         )
         current_file = self._get_current_file()
         self._ui.browser.select_work_area(app.context)

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -38,26 +38,17 @@ class FileSaveForm(FileFormBase):
     UI for saving a work file
     """
 
-    @property
-    def exit_code(self):
-        return self._exit_code
-
     def __init__(self, parent=None):
         """
         Construction
         """
-        app = sgtk.platform.current_bundle()
-
-        FileFormBase.__init__(self, parent)
+        super(FileSaveForm, self).__init__(parent)
 
         self._expanded_size = QtCore.QSize(930, 700)
         self._collapsed_size = None
-
-        self._exit_code = QtGui.QDialog.Rejected
         self._current_env = None
         self._extension_choices = []
         self._preview_task = None
-        self._navigating = False
 
         font_colour = self.palette().text().color()
         if font_colour.value() < 0.5:
@@ -83,7 +74,11 @@ class FileSaveForm(FileFormBase):
             self._start_preview_update()
         except:
             self._allow_preview_update = True
+            app = sgtk.platform.current_bundle()
             app.log_exception("Unhandled exception during File Save Form construction!")
+
+    def init_ui_file(self):
+        return Ui_FileSaveForm()
 
     def _do_init(self):
         """
@@ -91,9 +86,7 @@ class FileSaveForm(FileFormBase):
         """
         app = sgtk.platform.current_bundle()
 
-        # set up the UI
-        self._ui = Ui_FileSaveForm()
-        self._ui.setupUi(self)
+        super(FileSaveForm, self)._do_init()
 
         self._ui.preview_label.setText(
             "<p style='color:rgb%s'><b>Preview:</b></p>" % (self._preview_colour,)
@@ -130,7 +123,6 @@ class FileSaveForm(FileFormBase):
         self._ui.version_spinner.setEnabled(False)
 
         # hook up signals on controls:
-        self._ui.cancel_btn.clicked.connect(self._on_cancel)
         self._ui.save_btn.clicked.connect(self._on_save)
         self._ui.expand_checkbox.toggled.connect(self._on_expand_toggled)
         self._ui.name_edit.textEdited.connect(self._on_name_edited)
@@ -143,15 +135,10 @@ class FileSaveForm(FileFormBase):
             self._on_use_next_available_version_toggled
         )
 
-        self._ui.browser.create_new_task.connect(self._on_create_new_task)
         self._ui.browser.file_selected.connect(self._on_browser_file_selected)
         self._ui.browser.file_double_clicked.connect(
             self._on_browser_file_double_clicked
         )
-        self._ui.browser.work_area_changed.connect(self._on_browser_work_area_changed)
-        self._ui.browser.step_filter_changed.connect(self._apply_step_filtering)
-        self._ui.nav.navigate.connect(self._on_navigate)
-        self._ui.nav.home_clicked.connect(self._on_navigate_home)
 
         # initialize the browser:
         self._ui.browser.enable_show_all_versions(False)
@@ -175,18 +162,6 @@ class FileSaveForm(FileFormBase):
         if not env or not env.work_template:
             self._ui.expand_checkbox.setChecked(True)
             self._on_expand_toggled(True)
-
-    def closeEvent(self, event):
-        """
-        Called when the widget is being closed - do as much as possible here to help the GC
-
-        :param event:   The close event
-        """
-        # clean up the browser:
-        self._ui.browser.shut_down()
-
-        # be sure to call the base clase implementation
-        return FileFormBase.closeEvent(self, event)
 
     # ------------------------------------------------------------------------------------------
     # protected methods
@@ -517,7 +492,8 @@ class FileSaveForm(FileFormBase):
         """
         Invoked when the selection changes in My Tasks or one of the entity views.
         """
-        env = None
+        # This overrides the base implementation since we need to change the state of the preview
+        # when an environment can't be found
         if entity:
             app = sgtk.platform.current_bundle()
             context = app.sgtk.context_from_entity_dictionary(entity)
@@ -535,27 +511,6 @@ class FileSaveForm(FileFormBase):
             destination_label = breadcrumbs[-1].label if breadcrumbs else "..."
             self._ui.nav.add_destination(destination_label, breadcrumbs)
         self._ui.breadcrumbs.set(breadcrumbs)
-
-    def _on_navigate(self, breadcrumb_trail):
-        """
-        """
-        if not breadcrumb_trail:
-            return
-
-        # awesome, just navigate to the breadcrumbs:
-        self._ui.breadcrumbs.set(breadcrumb_trail)
-        self._navigating = True
-        try:
-            self._ui.browser.navigate_to(breadcrumb_trail)
-        finally:
-            self._navigating = False
-
-    def _on_navigate_home(self):
-        """
-        Navigate to the current work area
-        """
-        app = sgtk.platform.current_bundle()
-        self._ui.browser.select_work_area(app.context)
 
     def _on_selected_file_changed(self, file):
         """
@@ -713,13 +668,6 @@ class FileSaveForm(FileFormBase):
 
             # resize the window to the collapsed size:
             self.window().resize(self._collapsed_size)
-
-    def _on_cancel(self):
-        """
-        Called when the cancel button is clicked
-        """
-        self._exit_code = QtGui.QDialog.Rejected
-        self.close()
 
     def _on_save(self):
         """

--- a/python/tk_multi_workfiles/file_save_form.py
+++ b/python/tk_multi_workfiles/file_save_form.py
@@ -72,12 +72,15 @@ class FileSaveForm(FileFormBase):
             # Manually invoke the preview update here so it is only called once due to the
             # _allow_preview_update flag.
             self._start_preview_update()
-        except:
+        except Exception:
             self._allow_preview_update = True
             app = sgtk.platform.current_bundle()
             app.log_exception("Unhandled exception during File Save Form construction!")
 
     def init_ui_file(self):
+        """
+        Returns the ui class to use, required by the base class.
+        """
         return Ui_FileSaveForm()
 
     def _do_init(self):

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -17,11 +17,16 @@ from .my_task_item_delegate import MyTaskItemDelegate
 from ..util import monitor_qobject_lifetime
 from ..entity_tree.entity_tree_form import EntityTreeForm
 
+from sgtk.platform.qt import QtCore
+
 
 class MyTasksForm(EntityTreeForm):
     """
     My Tasks widget class
     """
+
+    # emitted when an entity is double clicked
+    task_double_clicked = QtCore.Signal(object)
 
     def __init__(self, tasks_model, allow_task_creation, parent):
         """
@@ -52,6 +57,8 @@ class MyTasksForm(EntityTreeForm):
         monitor_qobject_lifetime(self._item_delegate)
         self._ui.entity_tree.setItemDelegate(self._item_delegate)
 
+        self._ui.entity_tree.doubleClicked.connect(self._on_double_clicked)
+
     def shut_down(self):
         """
         Clean up as much as we can to help the gc once the widget is finished with.
@@ -67,3 +74,10 @@ class MyTasksForm(EntityTreeForm):
                 self._item_delegate = None
         finally:
             self.blockSignals(signals_blocked)
+
+    def _on_double_clicked(self, idx):
+        """
+        Emits the entity that was double clicked.
+        """
+        entity_details = self._get_entity_details(idx)
+        self.task_double_clicked.emit(entity_details)

--- a/python/tk_multi_workfiles/ui/file_open_form.py
+++ b/python/tk_multi_workfiles/ui/file_open_form.py
@@ -53,6 +53,9 @@ class Ui_FileOpenForm(object):
 "}")
         self.open_btn.setObjectName("open_btn")
         self.horizontalLayout.addWidget(self.open_btn)
+        self.change_ctx_btn = QtGui.QPushButton(FileOpenForm)
+        self.change_ctx_btn.setObjectName("change_ctx_btn")
+        self.horizontalLayout.addWidget(self.change_ctx_btn)
         self.open_options_btn = QtGui.QPushButton(FileOpenForm)
         self.open_options_btn.setFlat(False)
         self.open_options_btn.setObjectName("open_options_btn")
@@ -68,6 +71,7 @@ class Ui_FileOpenForm(object):
         self.new_file_btn.setText(QtGui.QApplication.translate("FileOpenForm", "+ New File", None, QtGui.QApplication.UnicodeUTF8))
         self.cancel_btn.setText(QtGui.QApplication.translate("FileOpenForm", "Cancel", None, QtGui.QApplication.UnicodeUTF8))
         self.open_btn.setText(QtGui.QApplication.translate("FileOpenForm", "Open", None, QtGui.QApplication.UnicodeUTF8))
+        self.change_ctx_btn.setText(QtGui.QApplication.translate("FileOpenForm", "Change Context", None, QtGui.QApplication.UnicodeUTF8))
         self.open_options_btn.setText(QtGui.QApplication.translate("FileOpenForm", "...", None, QtGui.QApplication.UnicodeUTF8))
 
 from ..framework_qtwidgets import NavigationWidget, BreadcrumbWidget

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -102,7 +102,7 @@ class WorkFiles(object):
         handler = WorkFiles()
         from .file_open_form import FileOpenForm
 
-        handler._show_file_dlg("", FileOpenForm)
+        handler._show_file_dlg("File Open", FileOpenForm)
 
     @staticmethod
     def show_context_change_dlg():

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -102,7 +102,19 @@ class WorkFiles(object):
         handler = WorkFiles()
         from .file_open_form import FileOpenForm
 
-        handler._show_file_dlg("File Open", FileOpenForm)
+        handler._show_file_dlg("", FileOpenForm, FileOpenForm.FILE_MODE)
+
+    @staticmethod
+    def show_context_change_dlg():
+        """
+        Show the file open dialog
+        """
+        handler = WorkFiles()
+        from .file_open_form import FileOpenForm
+
+        handler._show_file_dlg(
+            "Change Context", FileOpenForm, FileOpenForm.CONTEXT_MODE
+        )
 
     @staticmethod
     def show_file_save_dlg():
@@ -114,7 +126,7 @@ class WorkFiles(object):
 
         handler._show_file_dlg("File Save", FileSaveForm)
 
-    def _show_file_dlg(self, dlg_name, form):
+    def _show_file_dlg(self, dlg_name, form, *args):
         """
         Shows the file dialog modally or not depending on the current DCC and settings.
 
@@ -123,6 +135,6 @@ class WorkFiles(object):
         """
         app = sgtk.platform.current_bundle()
         try:
-            self._dialog_launcher(dlg_name, app, form)
+            self._dialog_launcher(dlg_name, app, form, *args)
         except:
             app.log_exception("Failed to create %s dialog!" % dlg_name)

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -110,7 +110,7 @@ class WorkFiles(object):
         Show the file open dialog
         """
         handler = WorkFiles()
-        from .file_open_form import ContextChangeForm
+        from .context_change_form import ContextChangeForm
 
         handler._show_file_dlg("Change Context", ContextChangeForm)
 

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -102,7 +102,7 @@ class WorkFiles(object):
         handler = WorkFiles()
         from .file_open_form import FileOpenForm
 
-        handler._show_file_dlg("", FileOpenForm, FileOpenForm.FILE_MODE)
+        handler._show_file_dlg("", FileOpenForm)
 
     @staticmethod
     def show_context_change_dlg():
@@ -110,11 +110,9 @@ class WorkFiles(object):
         Show the file open dialog
         """
         handler = WorkFiles()
-        from .file_open_form import FileOpenForm
+        from .file_open_form import ContextChangeForm
 
-        handler._show_file_dlg(
-            "Change Context", FileOpenForm, FileOpenForm.CONTEXT_MODE
-        )
+        handler._show_file_dlg("Change Context", ContextChangeForm)
 
     @staticmethod
     def show_file_save_dlg():

--- a/resources/file_open_form.ui
+++ b/resources/file_open_form.ui
@@ -95,6 +95,13 @@ background-color: rgb(255, 128, 0);
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="change_ctx_btn">
+       <property name="text">
+        <string>Change Context</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="open_options_btn">
        <property name="text">
         <string>...</string>


### PR DESCRIPTION
Adds a context change mode that means the open and save app options are replaced by a context change app.
In context change mode it contains the entity/context navigation windows, but no file select. Once a context has been picked you can press change context.

Tasks in the My tasks can be view can be double clicked to change context, when in context change mode.

**Refactoring of the Open, Save and Context change forms**

Previously, the open and save dialog derive from the same `FileFormBase` class, but that class makes no assumption about the UI, because the save and open dialogs have different UIs.
However this meant a bunch of duplicated code in the derived classes, because both UI's shared common functionality.
Instead of opting to make context change a "mode" of the open dialog, I decided to make it it's own class derived from the `FileFormBase` and to cut down on the duplication across all three classes I moved a bunch of methods over to the base class. However this means that the base class now has some expectation of what will be in the UI.
I haven't but I could make the ui elements required by the base class, properties which the deriving classes must implement, although the element names would be identical in all cases so I felt this was overkill. Or I could revert to duplicating up the code again across all three classes.