### PR TITLE
SHOT-3645: Fix New Task dialog to only pop up once.

### DIFF
--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -75,7 +75,6 @@ class FileOpenForm(FileFormBase):
             self._on_browser_context_menu_requested
         )
 
-        self._ui.browser.create_new_task.connect(self._on_create_new_task)
         self._ui.browser.file_selected.connect(self._on_browser_file_selected)
         self._ui.browser.file_double_clicked.connect(
             self._on_browser_file_double_clicked


### PR DESCRIPTION
* New Task dialog will pop up a second time after creating a new task due to duplicated signal connection.
* Removed signal connection in `FileOpenForm` as it is already connected in the parent class `FileFormBase`