### PR TITLE
SHOT-3474: Include extra details on "New File" action error

### DIFF
--- a/python/tk_multi_workfiles/actions/new_file_action.py
+++ b/python/tk_multi_workfiles/actions/new_file_action.py
@@ -70,35 +70,54 @@ class NewFileAction(Action):
                 self._environment.context.as_template_fields(
                     self._environment.work_template, validate=True
                 )
-            except TankError as e:
-                # log the original exception (useful for tracking down the problem)
+            except TankError as tank_error:
                 self._app.log_exception(
                     "Unable to resolve template fields after folder creation!"
                 )
-                # and raise a new, clearer exception for this specific use case:
-                raise TankError(
-                    "Unable to resolve template fields after folder creation!  This could mean "
-                    "there is a mismatch between your folder schema and templates. Please "
-                    "contact us via {} if you need help fixing this.".format(
-                        support_url
-                    )
-                )
 
-            # reset the current scene:
-            if not reset_current_scene(
-                self._app, NEW_FILE_ACTION, self._environment.context
-            ):
-                self._app.log_debug(
-                    "Unable to perform New Scene operation after failing to reset scene!"
+                error_title = "Failed to complete '{}' action".format(self.label)
+                error_text = "{title}:\n\n{body}".format(
+                    title=error_title,
+                    body=(
+                        "Unable to resolve template fields after folder creation!  This could mean "
+                        "there is a mismatch between your folder schema and templates. Please "
+                        "contact us via {} if you need help fixing this.".format(
+                            support_url
+                        )
+                    ),
                 )
+                error_details = str(tank_error)
+
+                msg_box = QtGui.QMessageBox(
+                    QtGui.QMessageBox.Information,
+                    error_title,
+                    error_text,
+                    QtGui.QMessageBox.Ok,
+                    parent_ui,
+                )
+                msg_box.setDefaultButton(QtGui.QMessageBox.Ok)
+                if error_details:
+                    msg_box.setDetailedText(error_details)
+
+                msg_box.exec_()
                 return False
 
-            # prepare the new scene:
-            prepare_new_scene(self._app, NEW_FILE_ACTION, self._environment.context)
+            else:
+                # reset the current scene:
+                if not reset_current_scene(
+                    self._app, NEW_FILE_ACTION, self._environment.context
+                ):
+                    self._app.log_debug(
+                        "Unable to perform New Scene operation after failing to reset scene!"
+                    )
+                    return False
 
-            if not self._environment.context == self._app.context:
-                # Change context
-                FileAction.change_context(self._environment.context)
+                # prepare the new scene:
+                prepare_new_scene(self._app, NEW_FILE_ACTION, self._environment.context)
+
+                if not self._environment.context == self._app.context:
+                    # Change context
+                    FileAction.change_context(self._environment.context)
 
         except Exception as e:
             error_title = "Failed to complete '%s' action" % self.label


### PR DESCRIPTION
If an Asset has no type set, this error being reported to the user in the UI did not include the more accurate error message that was showing up in the log file:

![improve-error-flow](https://user-images.githubusercontent.com/66642500/106670981-c37c0600-657b-11eb-9beb-0f7672e41ed5.png)

With this change, the dialog includes an extra details message (if there are any details) that are shown when clicking "Show Details":

![Screen Shot 2021-02-02 at 5 23 29 PM](https://user-images.githubusercontent.com/66642500/106671134-ffaf6680-657b-11eb-892a-caa70c44fcbd.png)


See JIRA ticket for more detail: https://jira.autodesk.com/browse/SHOT-3474