### PR TITLE
Pointing to Azure CI Tools branch with Python 3.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/master
+      ref: refs/heads/SG-24238_Add_Python_3.9_Coverage_To_Azure_Pipelines-Tests
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:


### PR DESCRIPTION
Test pointing to a ci-tools Python 3.9 branch.