### PR TITLE
[SHOT-4065] Check references on file open

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,3 +45,4 @@ jobs:
     additional_repositories:
       - name: tk-framework-shotgunutils
       - name: tk-framework-qtwidgets
+        ref: custom-msg-box

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,4 +45,3 @@ jobs:
     additional_repositories:
       - name: tk-framework-shotgunutils
       - name: tk-framework-qtwidgets
-        ref: custom-msg-box

--- a/info.yml
+++ b/info.yml
@@ -241,6 +241,13 @@ configuration:
           type: str
         default_value: ['All', 'Working', 'Publishes']
 
+    show_check_references_option:
+        type: bool
+        description: True will show the checkbox option for the user to check for out of date
+                     references on file open action. False will hide the option and not
+                     references will not be checked on file open.
+        default_value: True
+
     check_references_on_file_open:
         type: bool
         description: Define if the references should be checked on file open.

--- a/info.yml
+++ b/info.yml
@@ -246,7 +246,7 @@ configuration:
         description: True will show the checkbox option for the user to check for out of date
                      references on file open action. False will hide the option and not
                      references will not be checked on file open.
-        default_value: True
+        default_value: False
 
     check_references_on_file_open:
         type: bool

--- a/info.yml
+++ b/info.yml
@@ -241,6 +241,11 @@ configuration:
           type: str
         default_value: ['All', 'Working', 'Publishes']
 
+    check_references_on_file_open:
+        type: bool
+        description: Define if the references should be checked on file open.
+        default_value: False
+
     # Save specific options
     #
 

--- a/info.yml
+++ b/info.yml
@@ -250,7 +250,8 @@ configuration:
 
     check_references_on_file_open:
         type: bool
-        description: Define if the references should be checked on file open.
+        description: Define if the references should be checked on file open. This will be
+                     ignored if 'show_check_references_option' is False.
         default_value: False
 
     # Save specific options

--- a/info.yml
+++ b/info.yml
@@ -290,4 +290,4 @@ supported_engines:
 frameworks:
     # We need a version of tk-framework-shotgunutils with a fix for deleting items.
     - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.3.5"}
-    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.10.4"}

--- a/python/tk_multi_workfiles/actions/interactive_open_action.py
+++ b/python/tk_multi_workfiles/actions/interactive_open_action.py
@@ -174,7 +174,13 @@ class InteractiveOpenAction(OpenFileAction):
             return False
 
         return self._do_copy_and_open(
-            None, file.path, file.version, False, env.context, parent_ui
+            None,
+            file.path,
+            file.version,
+            False,
+            env.context,
+            parent_ui,
+            check_refs=True,
         )
 
     def _open_publish_with_check(
@@ -315,7 +321,13 @@ class InteractiveOpenAction(OpenFileAction):
                     work_path = local_path
 
         return self._do_copy_and_open(
-            src_path, work_path, None, not file.editable, env.context, parent_ui
+            src_path,
+            work_path,
+            None,
+            not file.editable,
+            env.context,
+            parent_ui,
+            check_refs=True,
         )
 
     def _open_previous_publish(self, file, env, parent_ui):
@@ -344,6 +356,7 @@ class InteractiveOpenAction(OpenFileAction):
             read_only=True,
             new_ctx=env.context,
             parent_ui=parent_ui,
+            check_refs=False,
         )
 
     def _open_publish_read_only(self, file, env, parent_ui):
@@ -359,6 +372,7 @@ class InteractiveOpenAction(OpenFileAction):
             read_only=True,
             new_ctx=env.context,
             parent_ui=parent_ui,
+            check_refs=False,
         )
 
     def _open_publish_as_workfile(self, file, env, new_version, parent_ui):
@@ -437,5 +451,11 @@ class InteractiveOpenAction(OpenFileAction):
                 return False
 
         return self._do_copy_and_open(
-            src_path, work_path, None, not file.editable, env.context, parent_ui
+            src_path,
+            work_path,
+            None,
+            not file.editable,
+            env.context,
+            parent_ui,
+            check_refs=True,
         )

--- a/python/tk_multi_workfiles/actions/open_publish_actions.py
+++ b/python/tk_multi_workfiles/actions/open_publish_actions.py
@@ -52,6 +52,7 @@ class OpenPublishAction(OpenFileAction):
             read_only=self.file.editable,
             new_ctx=self.environment.context,
             parent_ui=parent_ui,
+            check_refs=False,
         )
 
 

--- a/python/tk_multi_workfiles/actions/open_workfile_actions.py
+++ b/python/tk_multi_workfiles/actions/open_workfile_actions.py
@@ -70,6 +70,7 @@ class OpenWorkfileAction(OpenFileAction):
             read_only=self.file.editable,
             new_ctx=self.environment.context,
             parent_ui=parent_ui,
+            check_refs=True,
         )
 
 

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -94,6 +94,7 @@ class BrowserForm(QtGui.QWidget):
         self._enable_show_all_versions = True
 
         self._show_user_filtering_widget = False
+        self._show_check_references_widget = False
         self._file_model = None
         self._my_tasks_form = None
         self._entity_tree_forms = []
@@ -198,6 +199,14 @@ class BrowserForm(QtGui.QWidget):
             if user sandboxing is configured for an entity inside the current selection.
         """
         self._show_user_filtering_widget = is_visible
+
+    def show_check_references_widget(self, is_visible):
+        """
+        Shows the check references option widget.
+
+        :param is_visible: If True, the check references checkbox will be shown.
+        """
+        self._show_check_references_widget = is_visible
 
     def set_models(self, my_tasks_model, entity_models, file_model):
         """
@@ -317,6 +326,10 @@ class BrowserForm(QtGui.QWidget):
         # Do not show the button by default, it will be revealed when the first
         # sandbox is detected.
         file_form.show_user_filtering_widget(self._show_user_filtering_widget)
+        # Only show the option to check references on file open when we are in file open mode
+        file_form.show_check_references_on_open_widget(
+            self._show_check_references_widget
+        )
         file_form.set_model(self._file_model)
         file_form.file_selected.connect(self._on_file_selected)
         file_form.file_double_clicked.connect(self.file_double_clicked)

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -186,7 +186,7 @@ class FileListForm(QtGui.QWidget):
 
         if checked is None:
             # No user setting defined, get the app setting value for the default value
-            checked = app.get_setting("check_references_on_file_open", False)
+            checked = app.get_setting(FileListForm.CHECK_REFS_USER_SETTING, False)
 
         return checked
 

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -300,6 +300,12 @@ class FileListForm(QtGui.QWidget):
 
         self._ui.check_refs_cb.setVisible(show)
 
+        if not show:
+            # Set the user preference to not check for reference on file open, if the UI option
+            # is not available. The scene operation checks for this user setting to determine
+            # if it should check references on open.
+            self.store_check_reference_setting(self._app, False)
+
     def select_file(self, file_item, context):
         """
         Select the specified file in the control views if possible.

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -81,7 +81,8 @@ class FileOpenForm(FileFormBase):
 
         # initialize the browser widget:
         self._ui.browser.show_user_filtering_widget(self._is_using_user_sandboxes())
-        self._ui.browser.show_check_references_widget(True)
+        show_check_refs = self._app.get_setting("show_check_references_option", False)
+        self._ui.browser.show_check_references_widget(show_check_refs)
         self._ui.browser.set_models(
             self._my_tasks_model,
             self._entity_models,

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -81,6 +81,7 @@ class FileOpenForm(FileFormBase):
 
         # initialize the browser widget:
         self._ui.browser.show_user_filtering_widget(self._is_using_user_sandboxes())
+        self._ui.browser.show_check_references_widget(True)
         self._ui.browser.set_models(
             self._my_tasks_model,
             self._entity_models,

--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -34,10 +34,11 @@ class FileOpenForm(FileFormBase):
     """
 
     def __init__(self, parent=None):
-        """
-        Construction
-        """
+        """Construction"""
+
         super(FileOpenForm, self).__init__(parent)
+
+        self._app = sgtk.platform.current_bundle()
 
         self._new_file_env = None
         self._default_open_action = None
@@ -47,8 +48,7 @@ class FileOpenForm(FileFormBase):
             # break the UI and crash the dcc horribly!
             self._do_init()
         except Exception:
-            app = sgtk.platform.current_bundle()
-            app.log_exception("Unhandled exception during Form construction!")
+            self._app.log_exception("Unhandled exception during Form construction!")
 
     def init_ui_file(self):
         """

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -51,3 +51,6 @@ HierarchicalFilteringProxyModel = models.HierarchicalFilteringProxyModel
 overlay_widget = sgtk.platform.import_framework(
     "tk-framework-qtwidgets", "overlay_widget"
 )
+
+message_box = sgtk.platform.import_framework("tk-framework-qtwidgets", "message_box")
+MessageBox = message_box.MessageBox

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -13,9 +13,15 @@ from sgtk import TankError
 from tank_vendor import six
 from sgtk.platform.qt import QtGui, QtCore
 
-OPEN_FILE_ACTION, SAVE_FILE_AS_ACTION, NEW_FILE_ACTION, VERSION_UP_FILE_ACTION = range(
-    4
-)
+from .framework_qtwidgets import MessageBox
+
+(
+    OPEN_FILE_ACTION,
+    SAVE_FILE_AS_ACTION,
+    NEW_FILE_ACTION,
+    VERSION_UP_FILE_ACTION,
+    CHECK_REFERENCES_ACTION,
+) = range(5)
 
 
 def _do_scene_operation(
@@ -52,6 +58,8 @@ def _do_scene_operation(
         action_str = "new_file"
     elif action == VERSION_UP_FILE_ACTION:
         action_str = "version_up"
+    elif action == CHECK_REFERENCES_ACTION:
+        action_str = "check_references"
     else:
         raise TankError("Unrecognised action %s for scene operation" % action)
 
@@ -148,3 +156,83 @@ def open_file(app, action, context, path, version, read_only):
         read_only,
         result_types=(bool, type(None)),
     )
+
+
+def check_references(app, action, context, parent_ui):
+    """
+    Use hook to check that all references in the current file exist.
+
+    If the hook did not check for references (returned None), then a default operation to
+    check for references will be performed using the Scene Breakdown2 API (if it is
+    available via the engine apps).
+
+    :return: The list of references that are not up to date with the latest version. None is
+        returned if the references could not be checked.
+    :rtype: list | None
+    """
+
+    app.log_debug("Checking references in the current file with hook")
+
+    # First check if there is a custom hook to check references
+    result = _do_scene_operation(
+        app,
+        action,
+        context,
+        "check_references",
+        result_types=(list, type(None)),
+    )
+
+    # Return the result, if the custom hook returned a value other than None (indicating it
+    # checked the references)
+    if result is not None:
+        return result
+
+    # No result returned, get the breakdown app to perform the default operation to check
+    # references
+    breakdown2_app = app.engine.apps.get("tk-multi-breakdown2")
+    if not breakdown2_app:
+        return None
+
+    # Use the breakdown manager to get the file references, then check if any are out of date
+    manager = breakdown2_app.create_breakdown_manager()
+    file_items = manager.scan_scene()
+    result = []
+    for file_item in file_items:
+        manager.get_latest_published_file(file_item)
+        if (
+            not file_item.highest_version_number
+            or file_item.sg_data["version_number"] < file_item.highest_version_number
+        ):
+            result.append(file_item)
+
+    if result:
+        # Out of date references were found, prompt the user how to handle them
+        msg_box = MessageBox()
+        msg_box.setWindowTitle("Reference Check")
+        msg_box.set_text("Found out of date references in current scene.")
+        msg_box.set_detailed_text(
+            "\n".join(
+                [
+                    (fi.sg_data.get("name") if fi.sg_data else fi.path) or fi.path
+                    for fi in result
+                ]
+            )
+        )
+        msg_box.set_always_show_details(True)
+        open_button = msg_box.add_button("Open in Breakdown", MessageBox.ACCEPT_ROLE)
+        ignore_button = msg_box.add_button("Ignore", MessageBox.REJECT_ROLE)
+        update_all_button = msg_box.add_button("Update All", MessageBox.APPLY_ROLE)
+        msg_box.set_default_button(update_all_button)
+
+        msg_box.exec_()
+
+        if msg_box.button_clicked == update_all_button:
+            # Update all references to the latest version
+            for file_item in result:
+                manager.update_to_latest_version(file_item)
+        elif msg_box.button_clicked == open_button:
+            # Open the breakdown app to see the out of date references in more details, where
+            # the user can manually fix any, if desired
+            breakdown2_app.show_dialog()
+
+    return result

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -179,12 +179,12 @@ def check_references(app, action, context, parent_ui):
         action,
         context,
         "check_references",
-        result_types=(list, type(None)),
+        result_types=(list, bool, type(None)),
     )
 
-    # Return the result, if the custom hook returned a value other than None (indicating it
-    # checked the references)
-    if result is not None:
+    # Return the result, if the custom hook returned a value of type list, otherwise
+    # assume that the default reference check should be performed.
+    if isinstance(result, list):
         return result
 
     # No result returned, get the breakdown app to perform the default operation to check

--- a/python/tk_multi_workfiles/ui/file_list_form.py
+++ b/python/tk_multi_workfiles/ui/file_list_form.py
@@ -70,6 +70,9 @@ class Ui_FileListForm(object):
         self.all_versions_cb = QtGui.QCheckBox(FileListForm)
         self.all_versions_cb.setObjectName("all_versions_cb")
         self.horizontalLayout_3.addWidget(self.all_versions_cb)
+        self.check_refs_cb = QtGui.QCheckBox(FileListForm)
+        self.check_refs_cb.setObjectName("check_refs_cb")
+        self.horizontalLayout_3.addWidget(self.check_refs_cb)
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
         self.horizontalLayout_3.addItem(spacerItem)
         self.search_ctrl = SearchWidget(FileListForm)
@@ -79,7 +82,7 @@ class Ui_FileListForm(object):
 "}")
         self.search_ctrl.setObjectName("search_ctrl")
         self.horizontalLayout_3.addWidget(self.search_ctrl)
-        self.horizontalLayout_3.setStretch(2, 1)
+        self.horizontalLayout_3.setStretch(3, 1)
         self.verticalLayout.addLayout(self.horizontalLayout_3)
         self.view_pages = QtGui.QStackedWidget(FileListForm)
         self.view_pages.setObjectName("view_pages")
@@ -113,6 +116,7 @@ class Ui_FileListForm(object):
         FileListForm.setWindowTitle(QtGui.QApplication.translate("FileListForm", "Form", None, QtGui.QApplication.UnicodeUTF8))
         self.user_filter_btn.setProperty("user_style", QtGui.QApplication.translate("FileListForm", "current", None, QtGui.QApplication.UnicodeUTF8))
         self.all_versions_cb.setText(QtGui.QApplication.translate("FileListForm", "All Versions", None, QtGui.QApplication.UnicodeUTF8))
+        self.check_refs_cb.setText(QtGui.QApplication.translate("FileListForm", "Check References on Open", None, QtGui.QApplication.UnicodeUTF8))
         self.search_ctrl.setAccessibleName(QtGui.QApplication.translate("FileListForm", "Search All Files", None, QtGui.QApplication.UnicodeUTF8))
 
 from ..file_list.file_details_view import FileDetailsView

--- a/resources/build_resources.sh
+++ b/resources/build_resources.sh
@@ -26,7 +26,7 @@ function build_qt {
     $1 $2 > $UI_PYTHON_PATH/$3.py
 
     # replace PySide imports with sgtk.platform.qt and remove line containing Created by date
-    sed -i $UI_PYTHON_PATH/$3.py -e "s/from PySide import/from sgtk.platform.qt import/g" -e "/# Created:/d"
+    sed -i "" -e "s/from PySide import/from sgtk.platform.qt import/g" -e "/# Created:/d" $UI_PYTHON_PATH/$3.py
 }
 
 function build_ui {

--- a/resources/file_list_form.ui
+++ b/resources/file_list_form.ui
@@ -30,7 +30,7 @@
     <number>2</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,1,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,1,0">
      <property name="leftMargin">
       <number>1</number>
      </property>
@@ -103,6 +103,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="check_refs_cb">
+       <property name="text">
+        <string>Check References on Open</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -142,7 +149,16 @@ background-color: rgb(255, 128, 0);
      </property>
      <widget class="QWidget" name="list_page">
       <layout class="QHBoxLayout" name="horizontalLayout_5">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -156,7 +172,16 @@ background-color: rgb(255, 128, 0);
      </widget>
      <widget class="QWidget" name="details_page">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>


### PR DESCRIPTION
* Add checkbox option next to "All Versions" to indicate if references should be checked on file open
* Only workfiles will be checked (not published), even if the option is toggled on
* If out of date references are found, a pop up dialog will be shown to ask the user how to handle them