### PR TITLE
SG-25609 Nuke 13 Crashes On Saving With a Custom Root Path

### DIFF
--- a/hooks/scene_operation_tk-nuke.py
+++ b/hooks/scene_operation_tk-nuke.py
@@ -102,7 +102,7 @@ class SceneOperation(HookClass):
 
         if operation == "current_path":
             # return the current script path
-            return nuke.root().name().replace("/", os.path.sep)
+            return nuke.root().name().replace(os.path.sep, "/")
 
         elif operation == "open":
             # open the specified script

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -8,6 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
+from sys import platform
 import types
 from sgtk import TankError
 from tank_vendor import six
@@ -133,6 +135,11 @@ def save_file(app, action, context, path=None):
     Use hook to save the current file
     """
     if path != None:
+        if platform == "win32":
+            # On Windows, this fixes the issue with Nuke 13 failing to save when
+            # we have path definitions in templates starting with 0, e.g.:
+            # shot_root: 08 sequences/{Sequence}/{Shot}/{Step}
+            path = path.replace(os.path.sep + "0", os.path.sep * 2 + "0")
         app.log_debug("Saving the current file as '%s' with hook" % path)
         _do_scene_operation(app, action, context, "save_as", path)
     else:

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -8,9 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 import types
-import sgtk
 from sgtk import TankError
 from tank_vendor import six
 from sgtk.platform.qt import QtGui, QtCore

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -135,11 +135,6 @@ def save_file(app, action, context, path=None):
     Use hook to save the current file
     """
     if path != None:
-        if sgtk.util.is_windows():
-            # On Windows, this fixes the issue with Nuke 13 failing to save when
-            # we have path definitions in the template starting with 0, e.g.:
-            # shot_root: 08 sequences/{Sequence}/{Shot}/{Step}
-            path = path.replace(os.path.sep + "0", os.path.sep * 2 + "0")
         app.log_debug("Saving the current file as '%s' with hook" % path)
         _do_scene_operation(app, action, context, "save_as", path)
     else:

--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -9,8 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-from sys import platform
 import types
+import sgtk
 from sgtk import TankError
 from tank_vendor import six
 from sgtk.platform.qt import QtGui, QtCore
@@ -135,9 +135,9 @@ def save_file(app, action, context, path=None):
     Use hook to save the current file
     """
     if path != None:
-        if platform == "win32":
+        if sgtk.util.is_windows():
             # On Windows, this fixes the issue with Nuke 13 failing to save when
-            # we have path definitions in templates starting with 0, e.g.:
+            # we have path definitions in the template starting with 0, e.g.:
             # shot_root: 08 sequences/{Sequence}/{Shot}/{Step}
             path = path.replace(os.path.sep + "0", os.path.sep * 2 + "0")
         app.log_debug("Saving the current file as '%s' with hook" % path)


### PR DESCRIPTION
This PR  fixes the issue with Nuke 13 on Windows failing to save when we have path definitions in the template starting with `0`, e.g.:
` shot_root: 08 sequences/{Sequence}/{Shot}/{Step`