### PR TITLE
SG-29395: Ensure that the overlay is hidden on shut down.

### DIFF
--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -261,6 +261,8 @@ class EntityTreeForm(QtGui.QWidget):
                 self._ui.entity_tree.setModel(None)
                 if isinstance(view_model, EntityTreeProxyModel):
                     view_model.setSourceModel(None)
+            
+            self._refresh_overlay_widget.hide()
         finally:
             self.blockSignals(signals_blocked)
 

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -261,7 +261,7 @@ class EntityTreeForm(QtGui.QWidget):
                 self._ui.entity_tree.setModel(None)
                 if isinstance(view_model, EntityTreeProxyModel):
                     view_model.setSourceModel(None)
-            
+
             self._refresh_overlay_widget.hide()
         finally:
             self.blockSignals(signals_blocked)


### PR DESCRIPTION
* Without hiding the widget before shut down, the overlay spinner continues to fire timeout events to trigger animations.