### PR TITLE
SG-29904 Update string replace to be compatible with Nuke on win32

### DIFF
--- a/hooks/scene_operation_tk-nuke.py
+++ b/hooks/scene_operation_tk-nuke.py
@@ -98,7 +98,7 @@ class SceneOperation(HookClass):
         # If we didn't hit the Hiero or Nuke Studio case above, we can
         # continue with the typical Nuke scene operation logic.
         if file_path:
-            file_path = file_path.replace("/", os.path.sep)
+            file_path = file_path.replace(os.path.sep, "/")
 
         if operation == "current_path":
             # return the current script path


### PR DESCRIPTION
- Follow up from #120.
- Detected when Nuke 13.2v5 crashes when saving in ShotGrid
- Nuke uses a `/` as a separator on all platforms (including Windows)
