### PR TITLE
SG-30400 Retrieve thumbnails from any FileItem that has a 'thumbnail_path'

### DIFF
--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -842,11 +842,9 @@ class FileModel(QtGui.QStandardItemModel):
             # add to the list of valid files:
             valid_files[file_version_key] = file_item
 
-            # if this is from a published file then we want to retrieve the thumbnail
-            # if one is available:
+            # we want to retrieve the thumbnail if one is available:
             if (
-                file_item.is_published
-                and file_item.thumbnail_path
+                file_item.thumbnail_path
                 and not file_item.thumbnail
             ):
                 # request the thumbnail using the data retriever:

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -641,7 +641,6 @@ class FileModel(QtGui.QStandardItemModel):
 
         valid_group_keys = set()
         if self._current_searches and self._current_users:
-
             # get details about the users to run searches for:
             current_user_key = self._gen_entity_key(g_user_cache.current_user)
             have_current_user = False
@@ -843,10 +842,7 @@ class FileModel(QtGui.QStandardItemModel):
             valid_files[file_version_key] = file_item
 
             # we want to retrieve the thumbnail if one is available:
-            if (
-                file_item.thumbnail_path
-                and not file_item.thumbnail
-            ):
+            if file_item.thumbnail_path and not file_item.thumbnail:
                 # request the thumbnail using the data retriever:
                 request_id = self._sg_data_retriever.request_thumbnail(
                     file_item.thumbnail_path,


### PR DESCRIPTION
The filter_work_files hook allows you to provide a thumbnail, but it's not used due to the `file_item.is_published` requirement in the FileModel._process_files method. This leaves us unable to show thumbnails for working files.

With this requirement removed, the filter_work_files hook can provide thumbnails as a file URI:

```python
class FilterWorkFiles(HookClass):
    def execute(self, work_files, **kwargs):
        for wf in work_files:
            wf['work_file']['thumbnail'] = "file:///my_thumbnail.jpg"
        return work_files
```