### PR TITLE
Feature/new hook

### DIFF
--- a/hooks/file_action.py
+++ b/hooks/file_action.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook that creates folders if needed
+"""
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FileAction(HookBaseClass):
+    """
+    Implementation of the FileAction class
+    """
+
+    def create_folders(self, context):
+        """Create folders on the disk.
+
+        :param context: The context for which we need to create folders
+        :type context: sgtk.Context
+        """
+
+        ctx_entity = context.task or context.entity or context.project
+
+        self.logger.info("Creating filesystem structure...")
+        self.parent.sgtk.create_filesystem_structure(
+            ctx_entity.get("type"),
+            ctx_entity.get("id"),
+            engine=self.parent.engine.instance_name,
+        )
+        self.logger.info("Filesystem structure created.")

--- a/info.yml
+++ b/info.yml
@@ -119,6 +119,11 @@ configuration:
         description: Contains methods to retrieve custom user login and push user data when a
                      work file is saved.
 
+    file_action_hook:
+        type: hook
+        default_value: "{self}/file_action.py"
+        description: Hook which creates folders on disk.
+
     # General preferences
     #
     entities:
@@ -137,8 +142,8 @@ configuration:
                       *filters* a list of standard ShotGrid API filters, *hierarchy* a list of fields defining
                       the grouping in the sub-tree.
                       The optional *step_filter_on* setting is an Entity type and can be used to restrict
-                      the list of Steps used for filtering to only the Steps for the specified Entity type.
-"
+                      the list of Steps used for filtering to only the Steps for the specified Entity type."
+
         # For backward compatibility reasons we don't use the new deferred queries
         # by default. Using deferred queries, an Asset/Shot setup could be:
         # - caption: Assets (deferred)

--- a/python/tk_multi_workfiles/actions/file_action.py
+++ b/python/tk_multi_workfiles/actions/file_action.py
@@ -32,9 +32,6 @@ class FileAction(Action):
         # create folders:
         QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         try:
-            # (AD) - does this work with non-standard hierarchies? e.g. /Task/Entity?
-            ctx_entity = ctx.task or ctx.entity or ctx.project
-
             # FIXME: The launcher uses the defer_keyword setting, which allows to use keywords other
             # than the engine instance name, which is the default value in the launch app. Using
             # engine.instance_name is the best we can do at the moment because the is no way for workfiles
@@ -51,13 +48,14 @@ class FileAction(Action):
             # - Look for the settings of the launcher app in the destination context and extract the
             # defer_keyword setting and reuse it.
             #
-            # It may very well be that there's no solution that fits everyone and might warrant
-            # a hook.
-            app.sgtk.create_filesystem_structure(
-                ctx_entity.get("type"),
-                ctx_entity.get("id"),
-                engine=app.engine.instance_name,
+            app.execute_hook_method(
+                "file_action_hook",
+                "create_folders",
+                context=ctx,
             )
+        except:
+            app.log_exception("Failed to execute custom file action!")
+
         finally:
             QtGui.QApplication.restoreOverrideCursor()
 


### PR DESCRIPTION
- Create a new hook for directories creations.

We did that because we have some paths which contains some constrains in our schemas. And we need to make some actions on Shotgrid before calling `create_filesystem_structure()`.

We tried to just modify the `scene_operation` hook on the operation `prepare_new` and `save_as` but it doesn't work when we try to save a new file in a task where nothing has been created before and where we don't use the `New File` action button.

Thanks