### PR TITLE
SG-30567 Change string interpolation syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-
-# vscode
-.vscode

--- a/hooks/user_login.py
+++ b/hooks/user_login.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Shotgun Software Inc.
+# Copyright (c) 2023 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #

--- a/python/tk_multi_workfiles/user_cache.py
+++ b/python/tk_multi_workfiles/user_cache.py
@@ -152,7 +152,7 @@ class UserCache(Threaded):
                     "id": None,
                     "email": None,
                     "login": login_name,
-                    "name": f"{login_name} (System)",
+                    "name": "%s (System)" % login_name,
                     "image": None,
                 }
             except Exception as e:


### PR DESCRIPTION
To support DCCs running on Python 2 (Nuke 12).

Follow up from #124