### PR TITLE
SHOT-4259: Remove tk-alias engine to run at startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         # the behaviour can be very different.
         #
         # currently, we have done QA on the following engines:
-        SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax", "tk-alias", "tk-vred"]
+        SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax", "tk-vred"]
 
         if not hasattr(sgtk, "_tk_multi_workfiles2_launch_at_startup"):
 

--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ class MultiWorkFiles(sgtk.platform.Application):
         # the behaviour can be very different.
         #
         # currently, we have done QA on the following engines:
-        SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax", "tk-vred"]
+        SUPPORTED_ENGINES = ["tk-nuke", "tk-maya", "tk-3dsmax"]
 
         if not hasattr(sgtk, "_tk_multi_workfiles2_launch_at_startup"):
 


### PR DESCRIPTION
* tk-alias engine will be responsible for running the workfiles app at start up using the config setting `run_at_startup`
* tk-vred will also be removed from the workfiles2 supported engines list, to be consistent with tk-alias/Automotive apps