### PR TITLE
Fix / Update File List Form on Folder Double Clicked

### DIFF
--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -82,6 +82,7 @@ class BrowserForm(QtGui.QWidget):
     )  # file, env, pnt
     entity_type_focus_changed = QtCore.Signal(object)  # entity type
     step_filter_changed = QtCore.Signal(list)  # SG filter
+    folder_double_clicked = QtCore.Signal(object)  # folder
 
     task_double_clicked = QtCore.Signal(object)  # My tasks task double clicked
 
@@ -250,6 +251,7 @@ class BrowserForm(QtGui.QWidget):
                 step_entity_filter=step_entity_filter,
             )
             entity_form.entity_selected.connect(self._on_entity_selected)
+            self.folder_double_clicked.connect(entity_form.select_folder_entity)
             self._ui.task_browser_tabs.addTab(entity_form, caption)
             entity_form.create_new_task.connect(self.create_new_task)
             self._entity_tree_forms.append(entity_form)
@@ -333,6 +335,7 @@ class BrowserForm(QtGui.QWidget):
         file_form.set_model(self._file_model)
         file_form.file_selected.connect(self._on_file_selected)
         file_form.file_double_clicked.connect(self.file_double_clicked)
+        file_form.folder_double_clicked.connect(self.folder_double_clicked)
         file_form.file_context_menu_requested.connect(
             self._on_file_context_menu_requested
         )

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_form.py
@@ -278,6 +278,10 @@ class EntityTreeForm(QtGui.QWidget):
         """
         self.entity_model.ensure_data_for_context(context)
 
+    def select_folder_entity(self, folder):
+        self._reset_selection()
+        self.select_entity(folder['type'], folder["id"])
+        
     def select_entity(self, entity_type, entity_id):
         """
         Select the specified entity in the tree.

--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -44,6 +44,9 @@ class FileListForm(QtGui.QWidget):
     # Signal emitted whenever a file is double-clicked
     file_double_clicked = QtCore.Signal(object, object)  # file, env
 
+    # Signal emitted whenever a folder is double-clicked
+    folder_double_clicked = QtCore.Signal(object)  # folder
+
     # Signal emitted whenever a context menu is required for a file
     file_context_menu_requested = QtCore.Signal(
         object, object, QtCore.QPoint
@@ -605,8 +608,9 @@ class FileListForm(QtGui.QWidget):
         item_type = get_model_data(idx, FileModel.NODE_TYPE_ROLE)
         if item_type == FileModel.FOLDER_NODE_TYPE:
             # selection is a folder/child so move into it
-            # TODO
-            pass
+            selected_item = get_model_data(idx, FileModel.FOLDER_ENTITY_ROLE)
+            env_details = get_model_data(idx, FileModel.WORK_AREA_ROLE)
+            self.folder_double_clicked.emit(selected_item)
         elif item_type == FileModel.FILE_NODE_TYPE:
             # this is a file so perform the default action for the file
             selected_file = get_model_data(idx, FileModel.FILE_ITEM_ROLE)

--- a/python/tk_multi_workfiles/file_model.py
+++ b/python/tk_multi_workfiles/file_model.py
@@ -76,6 +76,7 @@ class FileModel(QtGui.QStandardItemModel):
     WORK_AREA_ROLE = _BASE_ROLE + 3  # WorkArea data
     SEARCH_STATUS_ROLE = _BASE_ROLE + 4  # search status data
     SEARCH_MSG_ROLE = _BASE_ROLE + 5  # search message data
+    FOLDER_ENTITY_ROLE = _BASE_ROLE + 6 # FolderEntity data
 
     class _BaseModelItem(QtGui.QStandardItem):
         """
@@ -197,6 +198,34 @@ class FileModel(QtGui.QStandardItemModel):
                 self, typ=FileModel.FOLDER_NODE_TYPE, text=name
             )
             self._entity = entity
+
+        def data(self, role):
+            """
+            Return the data from the item for the specified role.
+
+            :param role:    The role to return data for.
+            :returns:       Data for the specified role
+            """
+            if role == FileModel.FOLDER_ENTITY_ROLE:
+                return self._entity
+            else:
+                return FileModel._BaseModelItem.data(self, role)
+
+        def setData(self, value, role):
+            """
+            Set the data on the item for the specified role
+
+            :param value:   The value to set the data with
+            :param role:    The role to set the data for
+            """
+            if role == QtCore.Qt.DisplayRole:
+                # do nothing as it can't be set!
+                pass
+            elif role == FileModel.FOLDER_ENTITY_ROLE:
+                self._entity = value
+            else:
+                # call the base implementation:
+                FileModel._BaseModelItem.setData(self, value, role)
 
         @property
         def entity(self):


### PR DESCRIPTION
Navigate throught Shot Folder as File Explorer Standard Behavior on double clicked. 