### PR TITLE
Config v1.6.1 - RC4: Python2 SyntaxError in tk-multi-workfiles2

### DIFF
--- a/python/tk_multi_workfiles/file_list/file_list_form.py
+++ b/python/tk_multi_workfiles/file_list/file_list_form.py
@@ -831,7 +831,7 @@ class FileListForm(QtGui.QWidget):
         by other FileListForm objects.
         """
 
-        return f"{self._search_label}.{key}"
+        return "{}.{}".format(self._search_label, key)
 
     def _set_view_mode(self, mode_index):
         """


### PR DESCRIPTION
This PR addresses a bug encountered during the testing of the config v1.6.1-rc4 . This bug caused a SyntaxError in older versions of Houdini (17.5.460) and Nuke (12.0v8), which both still rely on Python 2.7.