### PR TITLE
SHOT-4267: Use ShotgunMenu instead of QMenu

### DIFF
--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -20,6 +20,8 @@ from .actions.file_action_factory import FileActionFactory
 from .actions.action import SeparatorAction, ActionGroup
 from .actions.new_file_action import NewFileAction
 
+from .framework_qtwidgets import ShotgunMenu
+
 from .file_form_base import FileFormBase
 from .ui.file_open_form import Ui_FileOpenForm
 
@@ -152,7 +154,7 @@ class FileOpenForm(FileFormBase):
             # build the menu and add the actions to it:
             menu = self._ui.open_options_btn.menu()
             if not menu:
-                menu = QtGui.QMenu(self._ui.open_options_btn)
+                menu = ShotgunMenu(self._ui.open_options_btn)
                 self._ui.open_options_btn.setMenu(menu)
             menu.clear()
             self._populate_open_menu(menu, file_actions[1:])
@@ -179,7 +181,7 @@ class FileOpenForm(FileFormBase):
             return
 
         # build the context menu:
-        context_menu = QtGui.QMenu(self.sender())
+        context_menu = ShotgunMenu(self.sender())
         self._populate_open_menu(context_menu, file_actions[1:])
 
         # map the point to a global position:

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -53,5 +53,8 @@ ViewItemDelegate = delegates.ViewItemDelegate
 sg_qicons = sgtk.platform.import_framework("tk-framework-qtwidgets", "sg_qicons")
 SGQIcon = sg_qicons.SGQIcon
 
+shotgun_menus = sgtk.platform.import_framework("tk-framework-qtwidgets", "shotgun_menus")
+ShotgunMenu = shotgun_menus.ShotgunMenu
+
 message_box = sgtk.platform.import_framework("tk-framework-qtwidgets", "message_box")
 MessageBox = message_box.MessageBox

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -53,7 +53,9 @@ ViewItemDelegate = delegates.ViewItemDelegate
 sg_qicons = sgtk.platform.import_framework("tk-framework-qtwidgets", "sg_qicons")
 SGQIcon = sg_qicons.SGQIcon
 
-shotgun_menus = sgtk.platform.import_framework("tk-framework-qtwidgets", "shotgun_menus")
+shotgun_menus = sgtk.platform.import_framework(
+    "tk-framework-qtwidgets", "shotgun_menus"
+)
 ShotgunMenu = shotgun_menus.ShotgunMenu
 
 message_box = sgtk.platform.import_framework("tk-framework-qtwidgets", "message_box")


### PR DESCRIPTION
* For style consistency across apps
* Fixes QMenu right-arrow display issue with PySide6