### PR TITLE
SG-35979 context cache 

### DIFF
--- a/python/tk_multi_workfiles/scene_operation.py
+++ b/python/tk_multi_workfiles/scene_operation.py
@@ -23,6 +23,11 @@ from .framework_qtwidgets import MessageBox
     CHECK_REFERENCES_ACTION,
 ) = range(5)
 
+DCCS_MULTIPLE_CONTEXT_CACHE = [
+    "tk-photoshopcc",
+    "tk-aftereffects",
+]
+
 
 def _do_scene_operation(
     app,
@@ -138,6 +143,9 @@ def save_file(app, action, context, path=None):
     else:
         app.log_debug("Saving the current file with hook")
         _do_scene_operation(app, action, context, "save")
+
+    if app.engine.name in DCCS_MULTIPLE_CONTEXT_CACHE:
+        app.engine._add_to_context_cache(path, context)
 
 
 def open_file(app, action, context, path, version, read_only):


### PR DESCRIPTION
- The context cache is saved at the time of the scene operation, specifically during the save process.