### PR TITLE
SG-38797 Improve the "New file" button state logic

### DIFF
--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -112,7 +112,9 @@ class FileOpenForm(FileFormBase):
     def _on_browser_file_selected(self, file, env):
         """ """
         self._on_selected_file_changed(file, env)
-        self._update_new_file_btn(env)
+        if file:
+            # Only validate the button state if a file is selected.
+            self._update_new_file_btn(env)
 
     def _on_browser_work_area_changed(self, entity, breadcrumbs):
         """


### PR DESCRIPTION
When opening a file, the "new file" button greys out when cycling through "All", "Working" and "Publishes" tabs.

Each time we switch from one tab to another, the signal for selected a file is triggered even if no file is selected, disabling the "New file" button. This PR attempts to fix that.