### PR TITLE
SG-2824 Sorting my tasks

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -143,8 +143,8 @@ configuration:
                       *filters* a list of standard Flow Production Tracking API filters, *hierarchy* a list of fields defining
                       the grouping in the sub-tree.
                       The optional *step_filter_on* setting is an Entity type and can be used to restrict
-                      the list of Steps used for filtering to only the Steps for the specified Entity type.
-"
+                      the list of Steps used for filtering to only the Steps for the specified Entity type."
+
         # For backward compatibility reasons we don't use the new deferred queries
         # by default. Using deferred queries, an Asset/Shot setup could be:
         # - caption: Assets (deferred)
@@ -241,6 +241,27 @@ configuration:
         type: bool
         description: Controls whether new tasks can be created from the app.
         default_value: True
+
+    sort_fields:
+        type: dict
+        description: Controls what fields appear for sorting in the UI.
+                     Currently the sort menu only shows on the left tasks tab.
+                     You can add any field that would normally be suitable for sorting a query
+                     by for the tab's given entity type.
+        allows_empty: True
+        default_value:
+            tasks:
+                - { field_code: due_date, display_name: Due Date }
+                - { field_code: start_date, display_name: Start Date }
+                - { field_code: sg_status_list, display_name: Status }
+                - { field_code: step, display_name: Step}
+        values:
+            type: list
+            values:
+                type: dict
+                items:
+                    field_code: { type: str }
+                    display_name: { type: str }
 
     file_browser_tabs:
         type: list

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -23,7 +23,7 @@ from .file_list.file_list_form import FileListForm
 from .file_model import FileModel
 from .util import value_to_str, get_sg_entity_name_field
 from .ui.browser_form import Ui_BrowserForm
-from .framework_qtwidgets import Breadcrumb, shotgun_menus, shotgun_fields
+from .framework_qtwidgets import Breadcrumb, SGQIcon, shotgun_menus, shotgun_fields
 
 from .file_filters import FileFilters
 from .util import monitor_qobject_lifetime, get_template_user_keys
@@ -791,8 +791,10 @@ class BrowserForm(QtGui.QWidget):
         # Actions group list ordered
         sort_actions = [sort_asc, sort_desc, separator, *field_sort_actions]
 
-        # By default it sorts in descending order and the default field is set in the configuration
-        sort_desc.setChecked(True)
+        # By default it sorts in ascending order
+        sort_asc.setChecked(True)
+        # Set the icon to match the default sort order
+        self._my_tasks_form.sort_menu_button.setIcon(SGQIcon.sort_asc())
 
         # Menu sort order actions
         sort_asc.triggered[()].connect(
@@ -865,9 +867,11 @@ class BrowserForm(QtGui.QWidget):
         if sort_order == "asc":
             actions_list[0].setChecked(True)
             actions_list[1].setChecked(False)
+            self._my_tasks_form.sort_menu_button.setIcon(SGQIcon.sort_asc())
         elif sort_order == "desc":
             actions_list[0].setChecked(False)
             actions_list[1].setChecked(True)
+            self._my_tasks_form.sort_menu_button.setIcon(SGQIcon.sort_desc())
 
         # Save the last menu item selected
         self._current_menu_sort_item = field

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -747,10 +747,10 @@ class BrowserForm(QtGui.QWidget):
             lambda: self._entity_field_menu.exec_(QtGui.QCursor.pos())
         )
 
-        # the fields manager is used to query which fields are supported
-        # for display. it can also be used to find out which fields are
-        # visible to the user and editable by the user. the fields manager
-        # needs time to initialize itself. once that's done, the widgets can
+        # The fields manager is used to query which fields are supported
+        # for display. It can also be used to find out which fields are
+        # visible to the user and editable by the user. The fields manager
+        # needs time to initialize itself. Once that's done, the widgets can
         # begin to be populated.
         fields_manager = shotgun_fields.ShotgunFieldManager(
             self, bg_task_manager=self._task_manager

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -873,7 +873,7 @@ class BrowserForm(QtGui.QWidget):
         if field:
             self.my_tasks_model.load_and_refresh(
                 extra_filter=self._extra_filter,  # Keep the filters from the combo box
-                extra_sorting=[{"field_name": field, "direction": sort_order}]
+                extra_sorting=[{"field_name": field, "direction": sort_order}],
             )
             self.my_tasks_model.data_refreshed.emit(True)
 

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -763,23 +763,11 @@ class BrowserForm(QtGui.QWidget):
         """
         Define a few simple filter methods for use by the menu
         """
-
-        def field_filter(field):
-            # none of the fields are included
-            return False
-
-        def checked_filter(field):
-            # none of the fields are checked
-            return False
-
-        def disabled_filter(field):
-            # none of the fields are disabled
-            return False
-
-        # attach the filters
-        self._entity_field_menu.set_field_filter(field_filter)
-        self._entity_field_menu.set_checked_filter(checked_filter)
-        self._entity_field_menu.set_disabled_filter(disabled_filter)
+        # Attach the filters
+        # None of the fields are included, checked, and disabled at startup
+        self._entity_field_menu.set_field_filter(lambda field: False)
+        self._entity_field_menu.set_checked_filter(lambda field: False)
+        self._entity_field_menu.set_disabled_filter(lambda field: False)
 
     def _sort_menu_actions(self, tab_name="tasks"):
         """

--- a/python/tk_multi_workfiles/browser_form.py
+++ b/python/tk_multi_workfiles/browser_form.py
@@ -833,7 +833,7 @@ class BrowserForm(QtGui.QWidget):
         # Remove the separator from the list
         sort_actions.remove(separator)
 
-    def load_sort_data(self, field, sort_action, actions_list, **sort_order):
+    def load_sort_data(self, field, sort_action, actions_list, sort_order=None):
         """
         Loads the data for MyTasks UI tab according to the selected
         menu sort option.
@@ -843,11 +843,7 @@ class BrowserForm(QtGui.QWidget):
         :param sort_order: Selected sort order.
         """
 
-        sort_order = (
-            sort_order.get("sort_order", None)
-            if sort_order
-            else self._current_menu_sort_order
-        )
+        sort_order = sort_order or self._current_menu_sort_order
 
         for action in actions_list:
             if action == sort_action:

--- a/python/tk_multi_workfiles/entity_models/extended_model.py
+++ b/python/tk_multi_workfiles/entity_models/extended_model.py
@@ -99,7 +99,9 @@ class ShotgunExtendedEntityModel(ShotgunEntityModel):
             filters.append(extra_filter)
         if extra_sorting:
             self._order = extra_sorting
-        self._load_data(self._entity_type, filters, self._hierarchy, self._fields, self._order)
+        self._load_data(
+            self._entity_type, filters, self._hierarchy, self._fields, self._order
+        )
         self.async_refresh()
 
     def update_filters(self, extra_filter):

--- a/python/tk_multi_workfiles/entity_models/extended_model.py
+++ b/python/tk_multi_workfiles/entity_models/extended_model.py
@@ -60,6 +60,7 @@ class ShotgunExtendedEntityModel(ShotgunEntityModel):
         self._original_filters = filters
         self._hierarchy = hierarchy
         self._fields = fields
+        self._order = []
         self._extra_filter = None
 
         # We keep track of which entities are in the model, so we can bail
@@ -85,7 +86,7 @@ class ShotgunExtendedEntityModel(ShotgunEntityModel):
         # step filtering should be disabled.
         return "step" in self._fields or "step" in self._hierarchy
 
-    def load_and_refresh(self, extra_filter=None):
+    def load_and_refresh(self, extra_filter=None, extra_sorting=None):
         """
         Load the data for this model and post a refresh.
 
@@ -96,7 +97,9 @@ class ShotgunExtendedEntityModel(ShotgunEntityModel):
         filters = self._original_filters[:]  # Copy the list to not update the reference
         if extra_filter:
             filters.append(extra_filter)
-        self._load_data(self._entity_type, filters, self._hierarchy, self._fields)
+        if extra_sorting:
+            self._order = extra_sorting
+        self._load_data(self._entity_type, filters, self._hierarchy, self._fields, self._order)
         self.async_refresh()
 
     def update_filters(self, extra_filter):

--- a/python/tk_multi_workfiles/entity_tree/entity_tree_proxy_model.py
+++ b/python/tk_multi_workfiles/entity_tree/entity_tree_proxy_model.py
@@ -27,11 +27,7 @@ class EntityTreeProxyModel(EntityProxyModel):
         """ """
         EntityProxyModel.__init__(self, parent, compare_sg_fields)
         self._only_show_my_tasks = False
-
-        # set proxy to auto sort alphabetically
-        self.setDynamicSortFilter(True)
         self.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
-        self.sort(0, QtCore.Qt.AscendingOrder)
 
     # @property
     def _get_only_show_my_tasks(self):

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -65,10 +65,12 @@ shotgun_fields = sgtk.platform.import_framework(
 )
 sg_qwidgets = sgtk.platform.import_framework("tk-framework-qtwidgets", "sg_qwidgets")
 
+
 class SGQIcon(sg_qicons.SGQIcon):
     """
     A wrapper for the SGQIcon class to include additional icon resources.
     """
+
     @classmethod
     def sort_asc(cls):
         return cls(cls.resource_version_details_path("sort_up"))

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -51,7 +51,6 @@ delegates = sgtk.platform.import_framework("tk-framework-qtwidgets", "delegates"
 ViewItemDelegate = delegates.ViewItemDelegate
 
 sg_qicons = sgtk.platform.import_framework("tk-framework-qtwidgets", "sg_qicons")
-SGQIcon = sg_qicons.SGQIcon
 
 shotgun_menus = sgtk.platform.import_framework(
     "tk-framework-qtwidgets", "shotgun_menus"
@@ -64,3 +63,23 @@ MessageBox = message_box.MessageBox
 shotgun_fields = sgtk.platform.import_framework(
     "tk-framework-qtwidgets", "shotgun_fields"
 )
+sg_qwidgets = sgtk.platform.import_framework("tk-framework-qtwidgets", "sg_qwidgets")
+
+class SGQIcon(sg_qicons.SGQIcon):
+    """
+    A wrapper for the SGQIcon class to include additional icon resources.
+    """
+    @classmethod
+    def sort_asc(cls):
+        return cls(cls.resource_version_details_path("sort_up"))
+
+    @classmethod
+    def sort_desc(cls):
+        return cls(cls.resource_version_details_path("sort_down"))
+
+    @classmethod
+    def resource_version_details_path(cls, name, ext="png"):
+        return ":/version_details/{icon_name}.{ext}".format(
+            icon_name=name,
+            ext=ext,
+        )

--- a/python/tk_multi_workfiles/framework_qtwidgets.py
+++ b/python/tk_multi_workfiles/framework_qtwidgets.py
@@ -60,3 +60,7 @@ ShotgunMenu = shotgun_menus.ShotgunMenu
 
 message_box = sgtk.platform.import_framework("tk-framework-qtwidgets", "message_box")
 MessageBox = message_box.MessageBox
+
+shotgun_fields = sgtk.platform.import_framework(
+    "tk-framework-qtwidgets", "shotgun_fields"
+)

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -17,7 +17,7 @@ from ..util import monitor_qobject_lifetime
 from ..entity_tree.entity_tree_form import EntityTreeForm
 from ..framework_qtwidgets import ViewItemDelegate
 
-from sgtk.platform.qt import QtCore
+from sgtk.platform.qt import QtCore, QtGui
 
 
 class MyTasksForm(EntityTreeForm):
@@ -58,6 +58,8 @@ class MyTasksForm(EntityTreeForm):
         self._ui.entity_tree.setItemDelegate(self._item_delegate)
 
         self._ui.entity_tree.doubleClicked.connect(self._on_double_clicked)
+
+        self._sort_button_setup()
 
     def shut_down(self):
         """
@@ -110,3 +112,10 @@ class MyTasksForm(EntityTreeForm):
         view.setRootIsDecorated(False)
 
         return delegate
+
+    def _sort_button_setup(self):
+        self.sort_menu_button = QtGui.QPushButton()
+        self.sort_menu_button.setText("Sort")
+        self.sort_menu_button.setObjectName("sort_menu_button")
+        self.sort_menu_button.setStyleSheet("border :None")
+        self._ui.horizontalLayout.addWidget(self.sort_menu_button)

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -15,7 +15,7 @@ of a Shotgun data model of my tasks, a text search and a filter control.
 
 from ..util import monitor_qobject_lifetime
 from ..entity_tree.entity_tree_form import EntityTreeForm
-from ..framework_qtwidgets import ViewItemDelegate
+from ..framework_qtwidgets import ViewItemDelegate, sg_qwidgets
 
 from sgtk.platform.qt import QtCore, QtGui
 
@@ -114,8 +114,9 @@ class MyTasksForm(EntityTreeForm):
         return delegate
 
     def _sort_button_setup(self):
-        self.sort_menu_button = QtGui.QPushButton()
+        self.sort_menu_button = sg_qwidgets.SGQToolButton()
         self.sort_menu_button.setText("Sort")
         self.sort_menu_button.setObjectName("sort_menu_button")
         self.sort_menu_button.setStyleSheet("border :None")
-        self._ui.horizontalLayout.addWidget(self.sort_menu_button)
+        self.sort_menu_button.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+        self._ui.horizontalLayout.addWidget(self.sort_menu_button)  # horizontalLayout_2

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_form.py
@@ -119,4 +119,5 @@ class MyTasksForm(EntityTreeForm):
         self.sort_menu_button.setObjectName("sort_menu_button")
         self.sort_menu_button.setStyleSheet("border :None")
         self.sort_menu_button.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
-        self._ui.horizontalLayout.addWidget(self.sort_menu_button)  # horizontalLayout_2
+        self.sort_menu_button.setMinimumHeight(24)
+        self._ui.horizontalLayout_2.addWidget(self.sort_menu_button)


### PR DESCRIPTION
Adds sorting for **My Tasks** left tab. It allows the user to provide custom fields in the `info.yml` file (assuming that they are valid fields to sort by).

<img width="946" alt="image" src="https://github.com/user-attachments/assets/6b569ae9-76a3-4fa3-8127-31364107e5d5" />


**Heavily inspired by:**
- https://github.com/shotgunsoftware/tk-multi-workfiles2/pull/147
- https://github.com/shotgunsoftware/tk-multi-shotgunpanel/pull/67
- https://github.com/shotgunsoftware/tk-multi-shotgunpanel/pull/96