### PR TITLE
SG-36372 Remove conditional that supports tk-nuke-writenode versions older than v0.1.11

### DIFF
--- a/hooks/scene_operation_tk-nuke.py
+++ b/hooks/scene_operation_tk-nuke.py
@@ -191,15 +191,6 @@ class SceneOperation(HookClass):
         if not write_node_app:
             return False
 
-        # only need to forceably reset the write node render paths if the app version
-        # is less than or equal to v0.1.11
-        from distutils.version import LooseVersion
-
-        if write_node_app.version == "Undefined" or LooseVersion(
-            write_node_app.version
-        ) > LooseVersion("v0.1.11"):
-            return False
-
         write_nodes = write_node_app.get_write_nodes()
         for write_node in write_nodes:
             write_node_app.reset_node_render_path(write_node)


### PR DESCRIPTION
Removes a conditional that supported versions before https://github.com/shotgunsoftware/tk-nuke-writenode/releases/tag/v0.1.11 which is from 2013

