### PR TITLE
SG-43221 fix: Restore case-insensitive search in File Open for PySide2 with QtCore5

### DIFF
--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -22,24 +22,32 @@ def create_case_insensitive_regex(pattern):
     """
     Create a case-insensitive regular expression compatible with both PySide2 and PySide6.
 
-    In PySide6, QRegExp was replaced with QRegularExpression. The patcher in tk-core
-    has issues mapping the case sensitivity options correctly, so we create the
-    QRegularExpression directly when available.
+    Qt6 removed QRegExp entirely and reorganized the QRegularExpression flag enums,
+    so the Qt major version is used to determine which API to use. In Qt5, QRegExp
+    is preferred with FixedString syntax to treat the pattern as a literal string
+    rather than a regex. In Qt6+, QRegularExpression is used with CaseInsensitiveOption
+    applied via setPatternOptions.
 
-    :param pattern: The search pattern string
-    :returns: A QRegExp or QRegularExpression configured for case-insensitive matching
+    :param pattern: The literal search pattern string to match against.
+    :returns: A case-insensitive QRegExp (Qt5/PySide2) or QRegularExpression
+              (Qt6+/PySide6+) object configured for literal fixed-string matching.
     """
-    # Check if QRegularExpression is available (PySide6)
-    if hasattr(QtCore, "QRegularExpression"):
-        # Use QRegularExpression with CaseInsensitiveOption for PySide6
+    qt_major_version = int(QtCore.qVersion().split(".")[0])
+
+    if qt_major_version >= 6:
+        # Qt6+ removed QRegExp. Use QRegularExpression with CaseInsensitiveOption.
+        # setPatternOptions is used instead of the constructor flag argument to avoid
+        # differences in the PatternOption enum path between Qt versions.
         regex = QtCore.QRegularExpression(pattern)
         regex.setPatternOptions(QtCore.QRegularExpression.CaseInsensitiveOption)
-        return regex
     else:
-        # Fall back to QRegExp for PySide2
-        return QtCore.QRegExp(
+        # Qt5/PySide2 - use QRegExp with FixedString to treat the pattern as a
+        # literal string rather than a full regular expression.
+        regex = QtCore.QRegExp(
             pattern, QtCore.Qt.CaseInsensitive, QtCore.QRegExp.FixedString
         )
+
+    return regex
 
 
 class Threaded(object):


### PR DESCRIPTION
## Summary

Restores case-insensitive search behavior in the File Open dialog when running under **PySide2 with Qt5** (e.g., Maya 2022).

This resolves Issue #173.

The fix corrects version detection and aligns regex construction with the appropriate Qt API for each major version.

---

## Problem

Case-insensitive search stopped working in Maya environments that ship with **PySide2 + Qt5**. Filters behaved inconsistently depending on the Qt binding, particularly under newer Maya versions.

---

## Root Cause

The regex creation logic attempted to infer API behavior by checking for the presence of `QtCore.QRegularExpression`.

This approach is unreliable because:

* `QRegularExpression` exists in **Qt5**, but its flag handling differs from Qt6.
* **Qt6 removed `QRegExp` entirely** and reorganized `QRegularExpression` flag enums.
* The previous implementation did not properly distinguish between Qt major versions, leading to incorrect case-insensitivity handling.

As documented in Qt 5.15 ([QRegularExpression API reference](https://doc.qt.io/archives/qt-5.15/qregularexpression.html)), Qt5 exposes `QRegularExpression` and its flag enums via `QtCore`, but its behavior and preferred usage differ from Qt6.

---

## Solution

Use the **Qt major version** to determine which regex API to construct, instead of checking for attribute existence.

* **Qt5**

  * Prefer `QRegExp`
  * Use `FixedString` syntax
  * Apply `Qt.CaseInsensitive`
  * Treat patterns as literal strings (not regex)

* **Qt6+**

  * Use `QRegularExpression`
  * Apply `CaseInsensitiveOption` via `setPatternOptions`
  * Align with Qt6-only API surface (no `QRegExp`)

This makes the behavior explicit, version-correct, and stable across Maya 2022–2026.

---

## Changes

* Replace attribute-based detection with **Qt major version check**
* Normalize regex construction logic per Qt version
* Add inline documentation explaining Qt5 vs Qt6 differences
