### PR TITLE
fix: [SG-43221] correct PySide6 detection logic in create_case_insens…

### DIFF
--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -29,8 +29,8 @@ def create_case_insensitive_regex(pattern):
     :param pattern: The search pattern string
     :returns: A QRegExp or QRegularExpression configured for case-insensitive matching
     """
-    # Check if QRegularExpression is available (PySide6)
-    if hasattr(QtCore, "QRegularExpression"):
+    # Check if QRegExp is not available (PySide6)
+    if not hasattr(QtCore, "QRegExp"):
         # Use QRegularExpression with CaseInsensitiveOption for PySide6
         regex = QtCore.QRegularExpression(pattern)
         regex.setPatternOptions(QtCore.QRegularExpression.CaseInsensitiveOption)


### PR DESCRIPTION
…itive_regex

Issue or Context:
The create_case_insensitive_regex function was using incorrect logic to detect PySide6. It checked for the presence of QRegularExpression instead of checking for the absence of QRegExp.

Root Cause:
The condition `if hasattr(QtCore, "QRegularExpression")` doesn't reliably detect PySide6 because QRegularExpression can exist in both PySide2 (via compatibility layers) and PySide6. The correct approach is to check if QRegExp is NOT available, which definitively indicates PySide6.

Fix Applied:
- Changed condition from `if hasattr(QtCore, "QRegularExpression")` to `if not hasattr(QtCore, "QRegExp")`
- Updated comment to accurately reflect the logic: "Check if QRegExp is not available (PySide6)"
- This ensures QRegularExpression is used only in true PySide6 environments where QRegExp doesn't exist