### PR TITLE
SG-43221 Fix case-insensitive search regression under Qt5/PySide2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/master
+      ref: refs/heads/ticket/SG-43246-fix-ci
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/ticket/SG-43246-fix-ci
+      ref: refs/heads/master
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:

--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -32,9 +32,9 @@ def create_case_insensitive_regex(pattern):
     :returns: A case-insensitive QRegExp (Qt5/PySide2) or QRegularExpression
               (Qt6+/PySide6+) object configured for literal fixed-string matching.
     """
-    qt_major_version = int(QtCore.qVersion().split(".")[0])
-
-    if qt_major_version >= 6:
+    engine = sgtk.platform.current_engine()
+    
+    if engine.has_qt6:
         # Qt6+ removed QRegExp. Use QRegularExpression with CaseInsensitiveOption.
         # setPatternOptions is used instead of the constructor flag argument to avoid
         # differences in the PatternOption enum path between Qt versions.

--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -22,24 +22,32 @@ def create_case_insensitive_regex(pattern):
     """
     Create a case-insensitive regular expression compatible with both PySide2 and PySide6.
 
-    In PySide6, QRegExp was replaced with QRegularExpression. The patcher in tk-core
-    has issues mapping the case sensitivity options correctly, so we create the
-    QRegularExpression directly when available.
+    Qt6 removed QRegExp entirely and reorganized the QRegularExpression flag enums,
+    so the Qt major version is used to determine which API to use. In Qt5, QRegExp
+    is preferred with FixedString syntax to treat the pattern as a literal string
+    rather than a regex. In Qt6+, QRegularExpression is used with CaseInsensitiveOption
+    applied via setPatternOptions.
 
-    :param pattern: The search pattern string
-    :returns: A QRegExp or QRegularExpression configured for case-insensitive matching
+    :param pattern: The literal search pattern string to match against.
+    :returns: A case-insensitive QRegExp (Qt5/PySide2) or QRegularExpression
+              (Qt6+/PySide6+) object configured for literal fixed-string matching.
     """
-    # Check if QRegularExpression is available (PySide6)
-    if hasattr(QtCore, "QRegularExpression"):
-        # Use QRegularExpression with CaseInsensitiveOption for PySide6
+    qt_major_version = int(QtCore.qVersion().split(".")[0])
+
+    if qt_major_version >= 6:
+        # Qt6+ removed QRegExp. Use QRegularExpression with CaseInsensitiveOption.
+        # setPatternOptions is used instead of the constructor flag argument to avoid
+        # differences in the PatternOption enum path between Qt versions.
         regex = QtCore.QRegularExpression(pattern)
         regex.setPatternOptions(QtCore.QRegularExpression.CaseInsensitiveOption)
-        return regex
     else:
-        # Fall back to QRegExp for PySide2
-        return QtCore.QRegExp(
+        # Qt5/PySide2 - use QRegExp with FixedString to treat the pattern as a
+        # literal string rather than a full regular expression.
+        regex = QtCore.QRegExp(
             pattern, QtCore.Qt.CaseInsensitive, QtCore.QRegExp.FixedString
         )
+
+    return regex
 
 
 class Threaded(object):

--- a/python/tk_multi_workfiles/util.py
+++ b/python/tk_multi_workfiles/util.py
@@ -33,7 +33,7 @@ def create_case_insensitive_regex(pattern):
               (Qt6+/PySide6+) object configured for literal fixed-string matching.
     """
     engine = sgtk.platform.current_engine()
-    
+
     if engine.has_qt6:
         # Qt6+ removed QRegExp. Use QRegularExpression with CaseInsensitiveOption.
         # setPatternOptions is used instead of the constructor flag argument to avoid

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,9 +33,11 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
 
         self.QtCore = QtCore
 
-        # Detect Qt version to determine which code path should be used
-        self.qt_major_version = int(QtCore.qVersion().split(".")[0])
-        self.is_qt6 = self.qt_major_version >= 6
+        # Use the engine's has_qt6 property - same detection used by the production code
+        import sgtk
+
+        engine = sgtk.platform.current_engine()
+        self.is_qt6 = engine.has_qt6
 
         # Get the function from the imported module
         self.create_case_insensitive_regex = (

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,6 +33,10 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
 
         self.QtCore = QtCore
 
+        # Detect Qt version to determine which code path should be used
+        self.qt_major_version = int(QtCore.qVersion().split(".")[0])
+        self.is_qt6 = self.qt_major_version >= 6
+
         # Get the function from the imported module
         self.create_case_insensitive_regex = (
             self.tk_multi_workfiles.util.create_case_insensitive_regex
@@ -40,12 +44,12 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
 
     def test_returns_valid_regex_object(self):
         """
-        Test that the function returns a valid regex object.
+        Test that the function returns a valid regex object based on Qt version.
         """
         result = self.create_case_insensitive_regex("test")
 
-        # Should return either QRegExp or QRegularExpression
-        if hasattr(self.QtCore, "QRegularExpression"):
+        # Qt6+ should return QRegularExpression, Qt5 should return QRegExp
+        if self.is_qt6:
             self.assertIsInstance(result, self.QtCore.QRegularExpression)
         else:
             self.assertIsInstance(result, self.QtCore.QRegExp)
@@ -57,7 +61,7 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
         regex = self.create_case_insensitive_regex("cat")
 
         # Test matching - should match regardless of case
-        if hasattr(self.QtCore, "QRegularExpression"):
+        if self.is_qt6:
             # PySide6/QRegularExpression
             self.assertTrue(regex.match("cat").hasMatch())
             self.assertTrue(regex.match("Cat").hasMatch())
@@ -77,7 +81,7 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
         regex = self.create_case_insensitive_regex("CAT")
 
         # Test matching - should match regardless of case
-        if hasattr(self.QtCore, "QRegularExpression"):
+        if self.is_qt6:
             # PySide6/QRegularExpression
             self.assertTrue(regex.match("cat").hasMatch())
             self.assertTrue(regex.match("Cat").hasMatch())
@@ -95,7 +99,7 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
         regex = self.create_case_insensitive_regex("CaT")
 
         # Test matching - should match regardless of case
-        if hasattr(self.QtCore, "QRegularExpression"):
+        if self.is_qt6:
             # PySide6/QRegularExpression
             self.assertTrue(regex.match("cat").hasMatch())
             self.assertTrue(regex.match("CAT").hasMatch())
@@ -113,7 +117,7 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
         regex = self.create_case_insensitive_regex("")
 
         # Empty pattern should be valid
-        if hasattr(self.QtCore, "QRegularExpression"):
+        if self.is_qt6:
             self.assertIsInstance(regex, self.QtCore.QRegularExpression)
             self.assertTrue(regex.isValid())
         else:
@@ -126,7 +130,7 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
         """
         regex = self.create_case_insensitive_regex("my asset")
 
-        if hasattr(self.QtCore, "QRegularExpression"):
+        if self.is_qt6:
             self.assertTrue(regex.match("my asset").hasMatch())
             self.assertTrue(regex.match("My Asset").hasMatch())
             self.assertTrue(regex.match("MY ASSET").hasMatch())
@@ -142,17 +146,17 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
         pattern = "TestPattern"
         regex = self.create_case_insensitive_regex(pattern)
 
-        if hasattr(self.QtCore, "QRegularExpression"):
+        if self.is_qt6:
             self.assertEqual(regex.pattern(), pattern)
         else:
             self.assertEqual(regex.pattern(), pattern)
 
-    def test_case_insensitive_option_is_set_pyside6(self):
+    def test_case_insensitive_option_is_set_qt6(self):
         """
-        Test that CaseInsensitiveOption is set for PySide6/QRegularExpression.
+        Test that CaseInsensitiveOption is set for Qt6/QRegularExpression.
         """
-        if not hasattr(self.QtCore, "QRegularExpression"):
-            self.skipTest("QRegularExpression not available (PySide2 environment)")
+        if not self.is_qt6:
+            self.skipTest("Test only applicable to Qt6+ environment")
 
         regex = self.create_case_insensitive_regex("test")
 
@@ -163,14 +167,12 @@ class TestCreateCaseInsensitiveRegex(Workfiles2TestBase):
             "CaseInsensitiveOption should be set for QRegularExpression",
         )
 
-    def test_case_sensitivity_pyside2(self):
+    def test_case_sensitivity_qt5(self):
         """
-        Test that case sensitivity is set correctly for PySide2/QRegExp.
+        Test that case sensitivity is set correctly for Qt5/QRegExp.
         """
-        if hasattr(self.QtCore, "QRegularExpression"):
-            self.skipTest(
-                "Testing PySide2 behavior, but QRegularExpression is available"
-            )
+        if self.is_qt6:
+            self.skipTest("Test only applicable to Qt5 environment")
 
         regex = self.create_case_insensitive_regex("test")
 


### PR DESCRIPTION
Resolves #174

## Related JIRA Tickets
- [SG-43221](https://jira.autodesk.com/browse/SG-43221): File Open search is case-sensitive under PySide2/Qt5 in tk-multi-workfiles2

## Context
Community PR #174 by @kikeda-falcons identified that the `create_case_insensitive_regex` utility was using `hasattr(QtCore, "QRegularExpression")` to detect Qt version. This check is unreliable because `QRegularExpression` exists in both Qt5 and Qt6, causing incorrect branching and broken case-insensitive search in Maya 2022 (PySide2/Qt5).

The issue was originally introduced by https://github.com/shotgunsoftware/tk-multi-workfiles2/commit/a6bf78c16e6c43d479bac6acf46488a0a09eadaa

## Changes
- **`python/tk_multi_workfiles/util.py`**: Switch from attribute-presence detection to `engine.has_qt6` (the tk-core canonical way to detect which Qt binding is active). Qt5 uses `QRegExp` with `FixedString` syntax; Qt6+ uses `QRegularExpression` with `CaseInsensitiveOption`.
- **`tests/test_util.py`**: Update tests to use the same `engine.has_qt6` detection (`self.is_qt6`) to stay consistent with the production code.

## Credit
Original fix by [@kikeda-falcons](https://github.com/kikeda-falcons) in #174.