### PR TITLE
SG-37743 Fix template resolution in the case of pipeline step rename

### DIFF
--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -544,9 +544,9 @@ class FileFinder(QtCore.QObject):
             except TankError as exc:
                 # In this case, we cannot continue with any file system resolution, so just exit early instead.
                 self._app.log_debug(
-                    "Could not resolve template fields for context %s after "
+                    f"Could not resolve template fields for context {context} after "
                     "reconciling filesystem structure; returning no work files. "
-                    "Last error: %s" % (context, exc)
+                    "Last error: {exc}"
                 )
                 return []
 
@@ -601,8 +601,7 @@ class FileFinder(QtCore.QObject):
             return True
         except Exception as e:
             self._app.log_warning(
-                "Could not reconcile filesystem structure for context %s: %s"
-                % (context, e)
+                f"Could not reconcile filesystem structure for context {context}: {e}"
             )
             return False
 

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -571,7 +571,7 @@ class FileFinder(QtCore.QObject):
         )
         return work_file_paths
 
-    def _reconcile_filesystem_for_context(self, context):
+    def _reconcile_filesystem_for_context(self, context: sgtk.Context) -> bool:
         """
         Reconcile filesystem structure with current Shotgun state for the given
         context. Equivalent to the work `+ New File` triggers via

--- a/python/tk_multi_workfiles/file_finder.py
+++ b/python/tk_multi_workfiles/file_finder.py
@@ -529,12 +529,26 @@ class FileFinder(QtCore.QObject):
         work_fields = []
         try:
             work_fields = context.as_template_fields(work_template, validate=True)
-        except TankError as e:
-            # could not resolve fields from this context. This typically happens
+        except TankError as exc:
+            # Field resolution failed. This typically happens
             # when the context object does not have any corresponding objects on
-            # disk / in the path cache. In this case, we cannot continue with any
-            # file system resolution, so just exit early insted.
-            return []
+            # disk / in the path cache. It is also possible that the cause is a stale
+            # path cache — for example, after an entity short_name was renamed and
+            # `tank unregister_folders` ran without folders being recreated.
+            # In case it is the latter, mirror what "+ New File" does by reconciling the
+            # filesystem structure against current Shotgun state, then retry once.
+            if not self._reconcile_filesystem_for_context(context):
+                return []
+            try:
+                work_fields = context.as_template_fields(work_template, validate=True)
+            except TankError as exc:
+                # In this case, we cannot continue with any file system resolution, so just exit early instead.
+                self._app.log_debug(
+                    "Could not resolve template fields for context %s after "
+                    "reconciling filesystem structure; returning no work files. "
+                    "Last error: %s" % (context, exc)
+                )
+                return []
 
         # Build list of fields to ignore when looking for files, any missing key
         # is treated as a wildcard, which allows, for example to retrieve all files
@@ -556,6 +570,41 @@ class FileFinder(QtCore.QObject):
             work_template, work_fields, skip_fields, skip_missing_optional_keys=True
         )
         return work_file_paths
+
+    def _reconcile_filesystem_for_context(self, context):
+        """
+        Reconcile filesystem structure with current Shotgun state for the given
+        context. Equivalent to the work `+ New File` triggers via
+        FileAction.create_folders, but safe to call from a background worker
+        thread because it omits the Qt cursor override that requires the main
+        thread.
+
+        Walks the config's folder schema against current Shotgun data, creates
+        any missing folders on disk (idempotent — existing folders are left
+        alone), and refreshes path-cache entries with the current entity
+        short_names. After a successful call, a previously-failing
+        as_template_fields(validate=True) typically succeeds.
+
+        :param context: The toolkit context to reconcile.
+        :returns: True if reconciliation ran without error, False otherwise.
+        """
+        ctx_entity = context.task or context.entity or context.project
+        if not ctx_entity:
+            return False
+
+        try:
+            self._app.sgtk.create_filesystem_structure(
+                ctx_entity.get("type"),
+                ctx_entity.get("id"),
+                engine=self._app.engine.instance_name,
+            )
+            return True
+        except Exception as e:
+            self._app.log_warning(
+                "Could not reconcile filesystem structure for context %s: %s"
+                % (context, e)
+            )
+            return False
 
     def _filter_work_files(self, work_file_paths, valid_file_extensions):
         """

--- a/tests/test_file_finder.py
+++ b/tests/test_file_finder.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from unittest.mock import MagicMock, patch
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from workfiles2_test_base import Workfiles2TestBase
+from workfiles2_test_base import tearDownModule  # noqa
+
+from sgtk import TankError
+
+
+class TestReconcileFilesystemForContext(Workfiles2TestBase):
+
+    def setUp(self):
+        super().setUp()
+        FileFinder = self.tk_multi_workfiles.file_finder.FileFinder
+        self._finder = FileFinder()
+
+    def tearDown(self):
+        self._finder = None
+        super().tearDown()
+
+    def test_returns_false_when_context_has_no_entity(self):
+        ctx = MagicMock()
+        ctx.task = None
+        ctx.entity = None
+        ctx.project = None
+
+        result = self._finder._reconcile_filesystem_for_context(ctx)
+
+        self.assertFalse(result)
+
+    def test_returns_true_on_successful_create_filesystem_structure(self):
+        ctx = MagicMock()
+        ctx.task = {"type": "Task", "id": 1}
+        ctx.entity = None
+        ctx.project = None
+
+        with patch.object(
+            self._finder._app.sgtk, "create_filesystem_structure"
+        ) as mock_cfs:
+            result = self._finder._reconcile_filesystem_for_context(ctx)
+
+        self.assertTrue(result)
+
+    def test_passes_correct_args_to_create_filesystem_structure(self):
+        ctx = MagicMock()
+        ctx.task = {"type": "Task", "id": 42}
+        ctx.entity = None
+        ctx.project = None
+
+        with patch.object(
+            self._finder._app.sgtk, "create_filesystem_structure"
+        ) as mock_cfs:
+            self._finder._reconcile_filesystem_for_context(ctx)
+
+        mock_cfs.assert_called_once_with(
+            "Task", 42, engine=self._finder._app.engine.instance_name
+        )
+
+    def test_uses_entity_when_task_is_none(self):
+        ctx = MagicMock()
+        ctx.task = None
+        ctx.entity = {"type": "Asset", "id": 7}
+        ctx.project = None
+
+        with patch.object(
+            self._finder._app.sgtk, "create_filesystem_structure"
+        ) as mock_cfs:
+            result = self._finder._reconcile_filesystem_for_context(ctx)
+
+        mock_cfs.assert_called_once_with(
+            "Asset", 7, engine=self._finder._app.engine.instance_name
+        )
+        self.assertTrue(result)
+
+    def test_uses_project_when_task_and_entity_are_none(self):
+        ctx = MagicMock()
+        ctx.task = None
+        ctx.entity = None
+        ctx.project = {"type": "Project", "id": 3}
+
+        with patch.object(
+            self._finder._app.sgtk, "create_filesystem_structure"
+        ) as mock_cfs:
+            result = self._finder._reconcile_filesystem_for_context(ctx)
+
+        mock_cfs.assert_called_once_with(
+            "Project", 3, engine=self._finder._app.engine.instance_name
+        )
+        self.assertTrue(result)
+
+    def test_returns_false_and_logs_warning_on_exception(self):
+        ctx = MagicMock()
+        ctx.task = {"type": "Task", "id": 1}
+        ctx.entity = None
+        ctx.project = None
+
+        with patch.object(
+            self._finder._app.sgtk,
+            "create_filesystem_structure",
+            side_effect=Exception("disk error"),
+        ):
+            with patch.object(self._finder._app, "log_warning") as mock_warn:
+                result = self._finder._reconcile_filesystem_for_context(ctx)
+
+        self.assertFalse(result)
+        mock_warn.assert_called_once()
+
+
+class TestFindWorkFilesReconcile(Workfiles2TestBase):
+
+    def setUp(self):
+        super().setUp()
+        FileFinder = self.tk_multi_workfiles.file_finder.FileFinder
+        self._finder = FileFinder()
+
+    def tearDown(self):
+        self._finder = None
+        super().tearDown()
+
+    def test_first_call_succeeds_no_reconcile(self):
+        ctx = MagicMock()
+        ctx.as_template_fields.return_value = {}
+
+        with patch.object(
+            self._finder._app.sgtk,
+            "paths_from_template",
+            return_value=["/a/b.ma"],
+        ):
+            with patch.object(
+                self._finder._app.sgtk, "create_filesystem_structure"
+            ) as mock_cfs:
+                result = self._finder._find_work_files(ctx, self.work_template, [])
+
+        self.assertEqual(result, ["/a/b.ma"])
+        mock_cfs.assert_not_called()
+
+    def test_reconcile_returns_false_returns_empty_list(self):
+        ctx = MagicMock()
+        ctx.as_template_fields.side_effect = TankError("stale")
+
+        with patch.object(
+            self._finder,
+            "_reconcile_filesystem_for_context",
+            return_value=False,
+        ):
+            result = self._finder._find_work_files(ctx, self.work_template, [])
+
+        self.assertEqual(result, [])
+
+    def test_reconcile_succeeds_retry_succeeds_returns_files(self):
+        ctx = MagicMock()
+        ctx.as_template_fields.side_effect = [TankError("first"), {}]
+
+        with patch.object(
+            self._finder,
+            "_reconcile_filesystem_for_context",
+            return_value=True,
+        ):
+            with patch.object(
+                self._finder._app.sgtk,
+                "paths_from_template",
+                return_value=["/c/d.ma"],
+            ):
+                result = self._finder._find_work_files(ctx, self.work_template, [])
+
+        self.assertEqual(result, ["/c/d.ma"])
+
+    def test_reconcile_succeeds_retry_raises_tank_error_logs_and_returns_empty(self):
+        ctx = MagicMock()
+        ctx.as_template_fields.side_effect = [TankError("first"), TankError("second")]
+
+        with patch.object(
+            self._finder,
+            "_reconcile_filesystem_for_context",
+            return_value=True,
+        ):
+            with patch.object(self._finder._app, "log_debug") as mock_debug:
+                result = self._finder._find_work_files(ctx, self.work_template, [])
+
+        self.assertEqual(result, [])
+        mock_debug.assert_called_once()

--- a/tests/test_file_finder.py
+++ b/tests/test_file_finder.py
@@ -18,6 +18,7 @@ from sgtk import TankError
 
 
 class TestReconcileFilesystemForContext(Workfiles2TestBase):
+    """Tests for FileFinder._reconcile_filesystem_for_context."""
 
     def setUp(self):
         super().setUp()
@@ -29,6 +30,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
         super().tearDown()
 
     def test_returns_false_when_context_has_no_entity(self):
+        """Return False when context has no task, entity, or project."""
         ctx = MagicMock()
         ctx.task = None
         ctx.entity = None
@@ -39,6 +41,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
         self.assertFalse(result)
 
     def test_returns_true_on_successful_create_filesystem_structure(self):
+        """Return True when create_filesystem_structure succeeds."""
         ctx = MagicMock()
         ctx.task = {"type": "Task", "id": 1}
         ctx.entity = None
@@ -52,6 +55,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
         self.assertTrue(result)
 
     def test_passes_correct_args_to_create_filesystem_structure(self):
+        """Forward entity type, id, and engine name to create_filesystem_structure."""
         ctx = MagicMock()
         ctx.task = {"type": "Task", "id": 42}
         ctx.entity = None
@@ -67,6 +71,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
         )
 
     def test_uses_entity_when_task_is_none(self):
+        """Fall back to context.entity when task is None."""
         ctx = MagicMock()
         ctx.task = None
         ctx.entity = {"type": "Asset", "id": 7}
@@ -83,6 +88,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
         self.assertTrue(result)
 
     def test_uses_project_when_task_and_entity_are_none(self):
+        """Fall back to context.project when both task and entity are None."""
         ctx = MagicMock()
         ctx.task = None
         ctx.entity = None
@@ -99,6 +105,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
         self.assertTrue(result)
 
     def test_returns_false_and_logs_warning_on_exception(self):
+        """Return False and log a warning when create_filesystem_structure raises."""
         ctx = MagicMock()
         ctx.task = {"type": "Task", "id": 1}
         ctx.entity = None
@@ -117,6 +124,7 @@ class TestReconcileFilesystemForContext(Workfiles2TestBase):
 
 
 class TestFindWorkFilesReconcile(Workfiles2TestBase):
+    """Tests for the reconcile-retry logic in FileFinder._find_work_files."""
 
     def setUp(self):
         super().setUp()
@@ -128,6 +136,7 @@ class TestFindWorkFilesReconcile(Workfiles2TestBase):
         super().tearDown()
 
     def test_first_call_succeeds_no_reconcile(self):
+        """Return files normally when as_template_fields succeeds on the first call."""
         ctx = MagicMock()
         ctx.as_template_fields.return_value = {}
 
@@ -145,6 +154,7 @@ class TestFindWorkFilesReconcile(Workfiles2TestBase):
         mock_cfs.assert_not_called()
 
     def test_reconcile_returns_false_returns_empty_list(self):
+        """Return [] when first as_template_fields raises and reconcile returns False."""
         ctx = MagicMock()
         ctx.as_template_fields.side_effect = TankError("stale")
 
@@ -158,6 +168,7 @@ class TestFindWorkFilesReconcile(Workfiles2TestBase):
         self.assertEqual(result, [])
 
     def test_reconcile_succeeds_retry_succeeds_returns_files(self):
+        """Return files when reconcile succeeds and the retry resolves fields."""
         ctx = MagicMock()
         ctx.as_template_fields.side_effect = [TankError("first"), {}]
 
@@ -176,6 +187,7 @@ class TestFindWorkFilesReconcile(Workfiles2TestBase):
         self.assertEqual(result, ["/c/d.ma"])
 
     def test_reconcile_succeeds_retry_raises_tank_error_logs_and_returns_empty(self):
+        """Return [] and log debug when reconcile succeeds but retry still raises TankError."""
         ctx = MagicMock()
         ctx.as_template_fields.side_effect = [TankError("first"), TankError("second")]
 


### PR DESCRIPTION
**Precondition:**
- User creates a workfile under a pipeline step
- User renames the pipeline step in SG
- User runs 'tank unregister_folders' command for original step folder on disk
- User manually renames step folder on disk to match new step name

**Problem:**
- Workfiles under the renamed step would not show up in the File Open app
- Clicking New File from the app would fix the issue

**Solution:**
- Catch the exception when an initial attempt to resolve the template path fails (this happens due to the fact that the path cache is still storing the old step name)
- Mimic the behaviour triggered by New File action, which is to invoke sgtk.create_filesystem_structure() - this will re-query SG and create an updated path cache with the proper links
- The fix implicitly fixes the re-name issue which incurs a slight cost in an edge case situation, but for happy path, does not add any extra work