### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -316,6 +316,7 @@ description: "Using this app you can browse, open and save your Work Files and P
 requires_shotgun_version:
 requires_core_version: "v0.19.18"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # the engines that this app can operate in:
 supported_engines:


### PR DESCRIPTION
Set `minimum_python_version` to `3.9` in `info.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)