### PR TITLE
SG-44704 Fix Workfiles2 context-menu actions under PySide6 6.11

### DIFF
--- a/python/tk_multi_workfiles/file_open_form.py
+++ b/python/tk_multi_workfiles/file_open_form.py
@@ -231,8 +231,8 @@ class FileOpenForm(FileFormBase):
                 add_separators = True
             else:
                 q_action = QtGui.QAction(action.label, menu)
-                q_action.triggered[()].connect(
-                    lambda a=action, checked=False: self._perform_action(a)
+                q_action.triggered.connect(
+                    lambda checked=False, a=action: self._perform_action(a)
                 )
                 menu.addAction(q_action)
                 add_separators = True


### PR DESCRIPTION
I am currently writing a custom engine which required a newer version of PySide6 (6.7.x+) - I am using 6.11.1 to be precise.
The app works just fine as usual. When trying to use any context-menu action in tk-multi-workfiles2, however, it would just silently fail.

I was able to narrow down the issue and solve the problem with this PR on my end. As far as I can tell, both new and older versions of PySide6 are working as intended with this patch.

Others have also encountered this issue, I believe. There is one other open PR and one open issue that seem related:
- https://github.com/shotgunsoftware/tk-multi-workfiles2/pull/85
- https://github.com/shotgunsoftware/tk-multi-workfiles2/issues/183

Below you can find a more detailed explanation of what I believe the issue to be and what the actual fix was for me.

## Issue

Workfiles2 currently connects context-menu actions using:

```python
q_action.triggered[()].connect(
    lambda a=action, checked=False: self._perform_action(a)
)
```

Under PySide6 6.11.1, `triggered[()]` invokes the callback with the signal’s `checked` boolean argument.

Python assigns that positional value to the lambda’s first parameter, `a`. As a result, the default value `a=action` is not used, and `a` becomes `False`.

This causes Workfiles2 to call:

```python
self._perform_action(False)
```

The method then exits without executing the selected context-menu action.

Older PySide6 versions tested (i.e. 6.5.8 in my case), do not pass the `checked` argument when using `triggered[()]`, which is why the existing implementation works in those environments.

## Fix

Connect to the signal directly and accept the `checked` argument as the first callback parameter:

```python
q_action.triggered.connect(
    lambda checked=False, a=action: self._perform_action(a)
)
```

This ensures that the signal’s boolean value is assigned to `checked`, while the Workfiles2 action remains captured by `a`.

## Testing

Verified the behavior with:

* PySide6 6.5.8
* PySide6 6.11.1

The updated callback preserves the correct Workfiles2 action and allows context-menu actions to execute across all tested versions.